### PR TITLE
feat(process): enforce issue-linked branch names and automate project board status

### DIFF
--- a/.github/workflows/merge-rules.yml
+++ b/.github/workflows/merge-rules.yml
@@ -30,6 +30,10 @@ on:
         description: "Validate PR titles against Conventional Commits"
         type: boolean
         default: true
+      branch-check-enabled:
+        description: "Enforce issue-linked branch name pattern"
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -101,9 +105,35 @@ jobs:
               );
             }
 
-            if (repo.allow_merge_commit || repo.allow_rebase_merge) {
-              core.warning(
-                'Non-squash merge methods are enabled. Disable merge commits and rebase ' +
-                'merges to enforce a clean linear history.'
+  branch-name:
+    name: Validate branch name
+    if: ${{ github.event_name != 'workflow_call' || inputs.branch-check-enabled }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch naming convention
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.payload.pull_request?.head?.ref ?? '';
+
+            // Exempt automated bots and long-lived base branches
+            const EXEMPT = /^(main|master|develop|staging|release\/|dependabot\/|renovate\/)/;
+            if (EXEMPT.test(branch)) {
+              core.info(`Branch '${branch}' is exempt from naming checks.`);
+              return;
+            }
+
+            // Expected: type/ISSUE_NUMBER-short-slug
+            // e.g. feat/42-add-oauth-flow  fix/123-null-crash
+            const VALID = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|hotfix|bugfix)\/\d+-[a-z0-9][a-z0-9-]*$/;
+
+            if (!VALID.test(branch)) {
+              core.setFailed(
+                `Branch name '${branch}' does not follow the required convention.\n` +
+                `Expected: <type>/<issue-number>-<slug>\n` +
+                `Example:  feat/42-add-oauth-flow\n` +
+                `Valid types: feat fix docs style refactor perf test build ci chore hotfix bugfix`
               );
+            } else {
+              core.info(`Branch name '${branch}' is valid.`);
             }

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,0 +1,368 @@
+# Project Board Automation
+#
+# Moves issue cards on the GitHub Project board automatically as work progresses:
+#
+#   Todo        — issue created (default on board add)
+#   In Progress — branch pushed that matches feat|fix|.../ISSUE-slug
+#   In Review   — PR opened → repo owner assigned as reviewer
+#   Done        — PR approved by the owner
+#
+# ── Setup required ────────────────────────────────────────────────────────────
+# Add a repository secret named GH_PROJECT_TOKEN containing a fine-grained PAT
+# with these permissions:
+#   Repository scope:  Pull requests → Read-only
+#   User scope:        Projects → Read and write
+#
+# Do NOT use a classic PAT — fine-grained only.
+#
+# ── Consumer repo usage ───────────────────────────────────────────────────────
+# jobs:
+#   board:
+#     uses: h-urena/copilot-agentic-standards/.github/workflows/project-automation.yml@main
+#     secrets:
+#       GH_PROJECT_TOKEN: ${{ secrets.GH_PROJECT_TOKEN }}
+#     with:
+#       project-number: 4
+#       project-owner: your-github-login
+#       repo-owner: your-github-login
+
+name: Project Board Automation
+
+on:
+  push:
+    branches-ignore: [main, master, develop, staging]
+  pull_request:
+    types: [opened, reopened, review_requested]
+  pull_request_review:
+    types: [submitted]
+  workflow_call:
+    secrets:
+      GH_PROJECT_TOKEN:
+        required: true
+    inputs:
+      project-number:
+        description: "GitHub Project number (visible in the project URL)"
+        required: true
+        type: number
+      project-owner:
+        description: "GitHub login that owns the project (user or org)"
+        required: true
+        type: string
+      repo-owner:
+        description: "GitHub login of the repo owner / required reviewer"
+        required: true
+        type: string
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  # ── Move linked issue to "In Progress" when a branch is pushed ────────────
+  branch-to-in-progress:
+    name: Branch pushed → In Progress
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Move issue to In Progress
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GH_PROJECT_TOKEN }}
+          script: |
+            const PROJECT_OWNER  = '${{ inputs.project-owner  || env.PROJECT_OWNER  }}' || context.repo.owner;
+            const PROJECT_NUMBER = parseInt('${{ inputs.project-number || env.PROJECT_NUMBER }}' || '4', 10);
+
+            const branch = context.ref.replace('refs/heads/', '');
+
+            // Extract issue number from: feat/42-slug  fix/7-some-thing
+            const match = branch.match(/^[a-z]+\/(\d+)-/);
+            if (!match) {
+              core.info(`Branch '${branch}' has no issue number — skipping.`);
+              return;
+            }
+            const issueNumber = parseInt(match[1], 10);
+            core.info(`Detected issue #${issueNumber} from branch '${branch}'.`);
+
+            await moveIssueOnBoard({ issueNumber, statusName: 'In Progress', PROJECT_OWNER, PROJECT_NUMBER });
+
+            async function moveIssueOnBoard({ issueNumber, statusName, PROJECT_OWNER, PROJECT_NUMBER }) {
+              const owner = context.repo.owner;
+              const repo  = context.repo.repo;
+
+              // 1. Resolve issue node ID
+              const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number: issueNumber });
+              const issueNodeId = issue.node_id;
+
+              // 2. Find project ID and status field
+              const projectData = await github.graphql(`
+                query($login: String!, $number: Int!) {
+                  user(login: $login) {
+                    projectV2(number: $number) {
+                      id
+                      fields(first: 20) {
+                        nodes {
+                          ... on ProjectV2SingleSelectField {
+                            id name
+                            options { id name }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }`, { login: PROJECT_OWNER, number: PROJECT_NUMBER });
+
+              const project = projectData.user.projectV2;
+              const statusField = project.fields.nodes.find(f => f.name === 'Status');
+              if (!statusField) { core.warning('No Status field found in project.'); return; }
+
+              const option = statusField.options.find(o => o.name === statusName);
+              if (!option) { core.warning(`Status option '${statusName}' not found.`); return; }
+
+              // 3. Find or add item in project
+              let itemId;
+              try {
+                const addResult = await github.graphql(`
+                  mutation($projectId: ID!, $contentId: ID!) {
+                    addProjectV2ItemById(input: { projectId: $projectId contentId: $contentId }) {
+                      item { id }
+                    }
+                  }`, { projectId: project.id, contentId: issueNodeId });
+                itemId = addResult.addProjectV2ItemById.item.id;
+              } catch (e) {
+                core.warning(`Could not add item to project: ${e.message}`);
+                return;
+              }
+
+              // 4. Set status
+              await github.graphql(`
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId
+                    itemId: $itemId
+                    fieldId: $fieldId
+                    value: { singleSelectOptionId: $optionId }
+                  }) { projectV2Item { id } }
+                }`, {
+                  projectId: project.id,
+                  itemId,
+                  fieldId: statusField.id,
+                  optionId: option.id,
+                });
+
+              core.info(`Issue #${issueNumber} moved to '${statusName}' on project board.`);
+            }
+
+  # ── Move linked issue to "In Review" when PR is opened ────────────────────
+  pr-to-in-review:
+    name: PR opened → In Review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request review and move to In Review
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GH_PROJECT_TOKEN }}
+          script: |
+            const PROJECT_OWNER  = '${{ inputs.project-owner  || env.PROJECT_OWNER  }}' || context.repo.owner;
+            const PROJECT_NUMBER = parseInt('${{ inputs.project-number || env.PROJECT_NUMBER }}' || '4', 10);
+            const REPO_OWNER     = '${{ inputs.repo-owner     || env.REPO_OWNER     }}' || context.repo.owner;
+
+            const pr       = context.payload.pull_request;
+            const prNumber = pr.number;
+            const prAuthor = pr.user.login;
+            const body     = pr.body ?? '';
+            const branch   = pr.head.ref;
+
+            // Request review from repo owner if they're not the author
+            if (prAuthor !== REPO_OWNER) {
+              try {
+                await github.rest.pulls.requestReviewers({
+                  owner: context.repo.owner,
+                  repo:  context.repo.repo,
+                  pull_number: prNumber,
+                  reviewers: [REPO_OWNER],
+                });
+                core.info(`Review requested from ${REPO_OWNER}.`);
+              } catch (err) {
+                core.warning(`Could not request review from ${REPO_OWNER}: ${err.message}`);
+              }
+            }
+
+            // Extract linked issue numbers
+            const issueNumbers = extractLinkedIssues(body, branch);
+            core.info(`Linked issues: ${issueNumbers.join(', ') || 'none'}`);
+
+            for (const issueNumber of issueNumbers) {
+              await moveIssueOnBoard({ issueNumber, statusName: 'In Review', PROJECT_OWNER, PROJECT_NUMBER });
+            }
+
+            function extractLinkedIssues(body, branch) {
+              const nums = new Set();
+              // PR body: Closes/Fixes/Resolves #N
+              const bodyMatches = body.matchAll(/(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi);
+              for (const m of bodyMatches) nums.add(parseInt(m[1], 10));
+              // Branch name: feat/42-slug
+              const branchMatch = branch.match(/^[a-z]+\/(\d+)-/);
+              if (branchMatch) nums.add(parseInt(branchMatch[1], 10));
+              return [...nums];
+            }
+
+            async function moveIssueOnBoard({ issueNumber, statusName, PROJECT_OWNER, PROJECT_NUMBER }) {
+              const owner = context.repo.owner;
+              const repo  = context.repo.repo;
+
+              const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number: issueNumber });
+              const issueNodeId = issue.node_id;
+
+              const projectData = await github.graphql(`
+                query($login: String!, $number: Int!) {
+                  user(login: $login) {
+                    projectV2(number: $number) {
+                      id
+                      fields(first: 20) {
+                        nodes {
+                          ... on ProjectV2SingleSelectField {
+                            id name
+                            options { id name }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }`, { login: PROJECT_OWNER, number: PROJECT_NUMBER });
+
+              const project = projectData.user.projectV2;
+              const statusField = project.fields.nodes.find(f => f.name === 'Status');
+              if (!statusField) { core.warning('No Status field found in project.'); return; }
+
+              const option = statusField.options.find(o => o.name === statusName);
+              if (!option) { core.warning(`Status option '${statusName}' not found.`); return; }
+
+              let itemId;
+              try {
+                const addResult = await github.graphql(`
+                  mutation($projectId: ID!, $contentId: ID!) {
+                    addProjectV2ItemById(input: { projectId: $projectId contentId: $contentId }) {
+                      item { id }
+                    }
+                  }`, { projectId: project.id, contentId: issueNodeId });
+                itemId = addResult.addProjectV2ItemById.item.id;
+              } catch (e) {
+                core.warning(`Could not add item to project: ${e.message}`);
+                return;
+              }
+
+              await github.graphql(`
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId
+                    itemId: $itemId
+                    fieldId: $fieldId
+                    value: { singleSelectOptionId: $optionId }
+                  }) { projectV2Item { id } }
+                }`, {
+                  projectId: project.id,
+                  itemId,
+                  fieldId: statusField.id,
+                  optionId: option.id,
+                });
+
+              core.info(`Issue #${issueNumber} moved to '${statusName}' on project board.`);
+            }
+
+  # ── Move linked issue to "Done" when PR is approved ───────────────────────
+  approval-to-done:
+    name: PR approved → Done
+    if: >
+      github.event_name == 'pull_request_review' &&
+      github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Move linked issues to Done
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GH_PROJECT_TOKEN }}
+          script: |
+            const PROJECT_OWNER  = '${{ inputs.project-owner  || env.PROJECT_OWNER  }}' || context.repo.owner;
+            const PROJECT_NUMBER = parseInt('${{ inputs.project-number || env.PROJECT_NUMBER }}' || '4', 10);
+
+            const body   = context.payload.pull_request.body ?? '';
+            const branch = context.payload.pull_request.head.ref;
+            const issueNumbers = extractLinkedIssues(body, branch);
+            core.info(`Linked issues: ${issueNumbers.join(', ') || 'none'}`);
+
+            for (const issueNumber of issueNumbers) {
+              await moveIssueOnBoard({ issueNumber, statusName: 'Done', PROJECT_OWNER, PROJECT_NUMBER });
+            }
+
+            function extractLinkedIssues(body, branch) {
+              const nums = new Set();
+              const bodyMatches = body.matchAll(/(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi);
+              for (const m of bodyMatches) nums.add(parseInt(m[1], 10));
+              const branchMatch = branch.match(/^[a-z]+\/(\d+)-/);
+              if (branchMatch) nums.add(parseInt(branchMatch[1], 10));
+              return [...nums];
+            }
+
+            async function moveIssueOnBoard({ issueNumber, statusName, PROJECT_OWNER, PROJECT_NUMBER }) {
+              const owner = context.repo.owner;
+              const repo  = context.repo.repo;
+
+              const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number: issueNumber });
+              const issueNodeId = issue.node_id;
+
+              const projectData = await github.graphql(`
+                query($login: String!, $number: Int!) {
+                  user(login: $login) {
+                    projectV2(number: $number) {
+                      id
+                      fields(first: 20) {
+                        nodes {
+                          ... on ProjectV2SingleSelectField {
+                            id name
+                            options { id name }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }`, { login: PROJECT_OWNER, number: PROJECT_NUMBER });
+
+              const project = projectData.user.projectV2;
+              const statusField = project.fields.nodes.find(f => f.name === 'Status');
+              if (!statusField) { core.warning('No Status field found in project.'); return; }
+
+              const option = statusField.options.find(o => o.name === statusName);
+              if (!option) { core.warning(`Status option '${statusName}' not found.`); return; }
+
+              let itemId;
+              try {
+                const addResult = await github.graphql(`
+                  mutation($projectId: ID!, $contentId: ID!) {
+                    addProjectV2ItemById(input: { projectId: $projectId contentId: $contentId }) {
+                      item { id }
+                    }
+                  }`, { projectId: project.id, contentId: issueNodeId });
+                itemId = addResult.addProjectV2ItemById.item.id;
+              } catch (e) {
+                core.warning(`Could not add item to project: ${e.message}`);
+                return;
+              }
+
+              await github.graphql(`
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId
+                    itemId: $itemId
+                    fieldId: $fieldId
+                    value: { singleSelectOptionId: $optionId }
+                  }) { projectV2Item { id } }
+                }`, {
+                  projectId: project.id,
+                  itemId,
+                  fieldId: statusField.id,
+                  optionId: option.id,
+                });
+
+              core.info(`Issue #${issueNumber} moved to '${statusName}' on project board.`);
+            }

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -67,8 +67,15 @@ jobs:
       - name: Move issue to In Progress
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_PROJECT_TOKEN }}
+          # Fall back to GITHUB_TOKEN so the action never crashes when the secret is absent.
+          # The script itself exits early if GH_PROJECT_TOKEN is not configured.
+          github-token: ${{ secrets.GH_PROJECT_TOKEN || github.token }}
           script: |
+            if ('${{ secrets.GH_PROJECT_TOKEN }}' === '') {
+              core.warning('GH_PROJECT_TOKEN secret is not configured. Skipping project board update. Add a fine-grained PAT with Projects write permission as a repository secret.');
+              return;
+            }
+
             const PROJECT_OWNER  = '${{ inputs.project-owner  || env.PROJECT_OWNER  }}' || context.repo.owner;
             const PROJECT_NUMBER = parseInt('${{ inputs.project-number || env.PROJECT_NUMBER }}' || '4', 10);
 
@@ -161,8 +168,13 @@ jobs:
       - name: Request review and move to In Review
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_PROJECT_TOKEN }}
+          github-token: ${{ secrets.GH_PROJECT_TOKEN || github.token }}
           script: |
+            if ('${{ secrets.GH_PROJECT_TOKEN }}' === '') {
+              core.warning('GH_PROJECT_TOKEN secret is not configured. Skipping project board update. Add a fine-grained PAT with Projects write permission as a repository secret.');
+              return;
+            }
+
             const PROJECT_OWNER  = '${{ inputs.project-owner  || env.PROJECT_OWNER  }}' || context.repo.owner;
             const PROJECT_NUMBER = parseInt('${{ inputs.project-number || env.PROJECT_NUMBER }}' || '4', 10);
             const REPO_OWNER     = '${{ inputs.repo-owner     || env.REPO_OWNER     }}' || context.repo.owner;
@@ -281,8 +293,13 @@ jobs:
       - name: Move linked issues to Done
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_PROJECT_TOKEN }}
+          github-token: ${{ secrets.GH_PROJECT_TOKEN || github.token }}
           script: |
+            if ('${{ secrets.GH_PROJECT_TOKEN }}' === '') {
+              core.warning('GH_PROJECT_TOKEN secret is not configured. Skipping project board update. Add a fine-grained PAT with Projects write permission as a repository secret.');
+              return;
+            }
+
             const PROJECT_OWNER  = '${{ inputs.project-owner  || env.PROJECT_OWNER  }}' || context.repo.owner;
             const PROJECT_NUMBER = parseInt('${{ inputs.project-number || env.PROJECT_NUMBER }}' || '4', 10);
 

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -8,7 +8,7 @@
 #   Done        — PR approved by the owner
 #
 # ── Setup required ────────────────────────────────────────────────────────────
-# Add a repository secret named GH_PROJECT_TOKEN containing a fine-grained PAT
+# Add a repository secret named PR_TOKEN containing a fine-grained PAT
 # with these permissions:
 #   Repository scope:  Pull requests → Read-only
 #   User scope:        Projects → Read and write
@@ -20,7 +20,7 @@
 #   board:
 #     uses: h-urena/copilot-agentic-standards/.github/workflows/project-automation.yml@main
 #     secrets:
-#       GH_PROJECT_TOKEN: ${{ secrets.GH_PROJECT_TOKEN }}
+#       PR_TOKEN: ${{ secrets.PR_TOKEN }}
 #     with:
 #       project-number: 4
 #       project-owner: your-github-login
@@ -37,7 +37,7 @@ on:
     types: [submitted]
   workflow_call:
     secrets:
-      GH_PROJECT_TOKEN:
+      PR_TOKEN:
         required: true
     inputs:
       project-number:
@@ -68,11 +68,11 @@ jobs:
         uses: actions/github-script@v7
         with:
           # Fall back to GITHUB_TOKEN so the action never crashes when the secret is absent.
-          # The script itself exits early if GH_PROJECT_TOKEN is not configured.
-          github-token: ${{ secrets.GH_PROJECT_TOKEN || github.token }}
+          # The script itself exits early if PR_TOKEN is not configured.
+          github-token: ${{ secrets.PR_TOKEN || github.token }}
           script: |
-            if ('${{ secrets.GH_PROJECT_TOKEN }}' === '') {
-              core.warning('GH_PROJECT_TOKEN secret is not configured. Skipping project board update. Add a fine-grained PAT with Projects write permission as a repository secret.');
+            if ('${{ secrets.PR_TOKEN }}' === '') {
+              core.warning('PR_TOKEN secret is not configured. Skipping project board update. Add a fine-grained PAT with Projects write permission as a repository secret.');
               return;
             }
 
@@ -168,10 +168,10 @@ jobs:
       - name: Request review and move to In Review
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_PROJECT_TOKEN || github.token }}
+          github-token: ${{ secrets.PR_TOKEN || github.token }}
           script: |
-            if ('${{ secrets.GH_PROJECT_TOKEN }}' === '') {
-              core.warning('GH_PROJECT_TOKEN secret is not configured. Skipping project board update. Add a fine-grained PAT with Projects write permission as a repository secret.');
+            if ('${{ secrets.PR_TOKEN }}' === '') {
+              core.warning('PR_TOKEN secret is not configured. Skipping project board update. Add a fine-grained PAT with Projects write permission as a repository secret.');
               return;
             }
 
@@ -293,10 +293,10 @@ jobs:
       - name: Move linked issues to Done
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_PROJECT_TOKEN || github.token }}
+          github-token: ${{ secrets.PR_TOKEN || github.token }}
           script: |
-            if ('${{ secrets.GH_PROJECT_TOKEN }}' === '') {
-              core.warning('GH_PROJECT_TOKEN secret is not configured. Skipping project board update. Add a fine-grained PAT with Projects write permission as a repository secret.');
+            if ('${{ secrets.PR_TOKEN }}' === '') {
+              core.warning('PR_TOKEN secret is not configured. Skipping project board update. Add a fine-grained PAT with Projects write permission as a repository secret.');
               return;
             }
 
@@ -383,3 +383,4 @@ jobs:
 
               core.info(`Issue #${issueNumber} moved to '${statusName}' on project board.`);
             }
+

--- a/composed/csharp-copilot-instructions.md
+++ b/composed/csharp-copilot-instructions.md
@@ -21,9 +21,12 @@ These are universal rules that apply to **every** repository regardless of langu
 ## Branch strategy
 
 - **`main`** is the default, protected branch. All changes merge into `main` via pull request.
-- Use short-lived feature branches: `feat/<ticket>-<short-description>`, `fix/<ticket>-<short-description>`, `docs/<ticket>-<short-description>`.
-- Bugfix branches: `bugfix/<ticket>-<short-description>` — branch from `main`, merge back to `main`.
-- Hotfix branches: `hotfix/<ticket>-<short-description>` — branch from `main`, merge back to `main`.
+- **Every branch must be linked to a GitHub issue.** No issue = no branch = no PR.
+- Branch name format: `<type>/<issue-number>-<short-description>`
+  - Examples: `feat/42-add-oauth-flow`, `fix/123-null-pointer-crash`, `chore/7-update-deps`
+  - Valid types: `feat` `fix` `docs` `style` `refactor` `perf` `test` `build` `ci` `chore` `hotfix` `bugfix`
+  - The slug must be lowercase, hyphen-separated, and start with the issue number.
+- Exempt from the naming rule: `main`, `develop`, `staging`, `release/*`, `dependabot/*`, `renovate/*`.
 - Delete branches after merge.
 
 ## Commit conventions
@@ -41,12 +44,24 @@ These are universal rules that apply to **every** repository regardless of langu
 
 ## Pull requests
 
-- PR title **must** follow Conventional Commits format (e.g., `feat: add user auth middleware`).
+- **Every PR must be linked to a GitHub issue.** Reference it in the PR body with `Closes #N`, `Fixes #N`, or `Resolves #N` so the issue closes automatically on merge.
+- PR title **must** follow Conventional Commits format (e.g., `feat(scope): add user auth middleware`).
 - Every PR must have a description explaining **what** changed and **why**.
 - Squash merge is the default merge strategy. Each PR becomes one commit on `main`.
 - PRs must pass all required status checks before merge.
-- Request at least one reviewer. Do not self-merge unless explicitly permitted.
+- The repo owner is automatically requested as reviewer when a PR is opened.
 - Keep PRs small and focused — one logical change per PR.
+
+## Project board lifecycle
+
+Every issue moves through these statuses automatically via CI:
+
+| Status | Trigger |
+|--------|--------|
+| **Todo** | Issue created and added to the board |
+| **In Progress** | Branch matching the issue number is pushed |
+| **In Review** | PR is opened (owner is auto-assigned as reviewer) |
+| **Done** | PR is approved by the owner |
 
 ## Code review expectations
 

--- a/composed/python-copilot-instructions.md
+++ b/composed/python-copilot-instructions.md
@@ -21,9 +21,12 @@ These are universal rules that apply to **every** repository regardless of langu
 ## Branch strategy
 
 - **`main`** is the default, protected branch. All changes merge into `main` via pull request.
-- Use short-lived feature branches: `feat/<ticket>-<short-description>`, `fix/<ticket>-<short-description>`, `docs/<ticket>-<short-description>`.
-- Bugfix branches: `bugfix/<ticket>-<short-description>` — branch from `main`, merge back to `main`.
-- Hotfix branches: `hotfix/<ticket>-<short-description>` — branch from `main`, merge back to `main`.
+- **Every branch must be linked to a GitHub issue.** No issue = no branch = no PR.
+- Branch name format: `<type>/<issue-number>-<short-description>`
+  - Examples: `feat/42-add-oauth-flow`, `fix/123-null-pointer-crash`, `chore/7-update-deps`
+  - Valid types: `feat` `fix` `docs` `style` `refactor` `perf` `test` `build` `ci` `chore` `hotfix` `bugfix`
+  - The slug must be lowercase, hyphen-separated, and start with the issue number.
+- Exempt from the naming rule: `main`, `develop`, `staging`, `release/*`, `dependabot/*`, `renovate/*`.
 - Delete branches after merge.
 
 ## Commit conventions
@@ -41,12 +44,24 @@ These are universal rules that apply to **every** repository regardless of langu
 
 ## Pull requests
 
-- PR title **must** follow Conventional Commits format (e.g., `feat: add user auth middleware`).
+- **Every PR must be linked to a GitHub issue.** Reference it in the PR body with `Closes #N`, `Fixes #N`, or `Resolves #N` so the issue closes automatically on merge.
+- PR title **must** follow Conventional Commits format (e.g., `feat(scope): add user auth middleware`).
 - Every PR must have a description explaining **what** changed and **why**.
 - Squash merge is the default merge strategy. Each PR becomes one commit on `main`.
 - PRs must pass all required status checks before merge.
-- Request at least one reviewer. Do not self-merge unless explicitly permitted.
+- The repo owner is automatically requested as reviewer when a PR is opened.
 - Keep PRs small and focused — one logical change per PR.
+
+## Project board lifecycle
+
+Every issue moves through these statuses automatically via CI:
+
+| Status | Trigger |
+|--------|--------|
+| **Todo** | Issue created and added to the board |
+| **In Progress** | Branch matching the issue number is pushed |
+| **In Review** | PR is opened (owner is auto-assigned as reviewer) |
+| **Done** | PR is approved by the owner |
 
 ## Code review expectations
 

--- a/composed/typescript-copilot-instructions.md
+++ b/composed/typescript-copilot-instructions.md
@@ -21,9 +21,12 @@ These are universal rules that apply to **every** repository regardless of langu
 ## Branch strategy
 
 - **`main`** is the default, protected branch. All changes merge into `main` via pull request.
-- Use short-lived feature branches: `feat/<ticket>-<short-description>`, `fix/<ticket>-<short-description>`, `docs/<ticket>-<short-description>`.
-- Bugfix branches: `bugfix/<ticket>-<short-description>` — branch from `main`, merge back to `main`.
-- Hotfix branches: `hotfix/<ticket>-<short-description>` — branch from `main`, merge back to `main`.
+- **Every branch must be linked to a GitHub issue.** No issue = no branch = no PR.
+- Branch name format: `<type>/<issue-number>-<short-description>`
+  - Examples: `feat/42-add-oauth-flow`, `fix/123-null-pointer-crash`, `chore/7-update-deps`
+  - Valid types: `feat` `fix` `docs` `style` `refactor` `perf` `test` `build` `ci` `chore` `hotfix` `bugfix`
+  - The slug must be lowercase, hyphen-separated, and start with the issue number.
+- Exempt from the naming rule: `main`, `develop`, `staging`, `release/*`, `dependabot/*`, `renovate/*`.
 - Delete branches after merge.
 
 ## Commit conventions
@@ -41,12 +44,24 @@ These are universal rules that apply to **every** repository regardless of langu
 
 ## Pull requests
 
-- PR title **must** follow Conventional Commits format (e.g., `feat: add user auth middleware`).
+- **Every PR must be linked to a GitHub issue.** Reference it in the PR body with `Closes #N`, `Fixes #N`, or `Resolves #N` so the issue closes automatically on merge.
+- PR title **must** follow Conventional Commits format (e.g., `feat(scope): add user auth middleware`).
 - Every PR must have a description explaining **what** changed and **why**.
 - Squash merge is the default merge strategy. Each PR becomes one commit on `main`.
 - PRs must pass all required status checks before merge.
-- Request at least one reviewer. Do not self-merge unless explicitly permitted.
+- The repo owner is automatically requested as reviewer when a PR is opened.
 - Keep PRs small and focused — one logical change per PR.
+
+## Project board lifecycle
+
+Every issue moves through these statuses automatically via CI:
+
+| Status | Trigger |
+|--------|--------|
+| **Todo** | Issue created and added to the board |
+| **In Progress** | Branch matching the issue number is pushed |
+| **In Review** | PR is opened (owner is auto-assigned as reviewer) |
+| **Done** | PR is approved by the owner |
 
 ## Code review expectations
 

--- a/instructions/base.md
+++ b/instructions/base.md
@@ -17,9 +17,12 @@ These are universal rules that apply to **every** repository regardless of langu
 ## Branch strategy
 
 - **`main`** is the default, protected branch. All changes merge into `main` via pull request.
-- Use short-lived feature branches: `feat/<ticket>-<short-description>`, `fix/<ticket>-<short-description>`, `docs/<ticket>-<short-description>`.
-- Bugfix branches: `bugfix/<ticket>-<short-description>` — branch from `main`, merge back to `main`.
-- Hotfix branches: `hotfix/<ticket>-<short-description>` — branch from `main`, merge back to `main`.
+- **Every branch must be linked to a GitHub issue.** No issue = no branch = no PR.
+- Branch name format: `<type>/<issue-number>-<short-description>`
+  - Examples: `feat/42-add-oauth-flow`, `fix/123-null-pointer-crash`, `chore/7-update-deps`
+  - Valid types: `feat` `fix` `docs` `style` `refactor` `perf` `test` `build` `ci` `chore` `hotfix` `bugfix`
+  - The slug must be lowercase, hyphen-separated, and start with the issue number.
+- Exempt from the naming rule: `main`, `develop`, `staging`, `release/*`, `dependabot/*`, `renovate/*`.
 - Delete branches after merge.
 
 ## Commit conventions
@@ -37,12 +40,24 @@ These are universal rules that apply to **every** repository regardless of langu
 
 ## Pull requests
 
-- PR title **must** follow Conventional Commits format (e.g., `feat: add user auth middleware`).
+- **Every PR must be linked to a GitHub issue.** Reference it in the PR body with `Closes #N`, `Fixes #N`, or `Resolves #N` so the issue closes automatically on merge.
+- PR title **must** follow Conventional Commits format (e.g., `feat(scope): add user auth middleware`).
 - Every PR must have a description explaining **what** changed and **why**.
 - Squash merge is the default merge strategy. Each PR becomes one commit on `main`.
 - PRs must pass all required status checks before merge.
-- Request at least one reviewer. Do not self-merge unless explicitly permitted.
+- The repo owner is automatically requested as reviewer when a PR is opened.
 - Keep PRs small and focused — one logical change per PR.
+
+## Project board lifecycle
+
+Every issue moves through these statuses automatically via CI:
+
+| Status | Trigger |
+|--------|--------|
+| **Todo** | Issue created and added to the board |
+| **In Progress** | Branch matching the issue number is pushed |
+| **In Review** | PR is opened (owner is auto-assigned as reviewer) |
+| **Done** | PR is approved by the owner |
 
 ## Code review expectations
 

--- a/workflows/reusable/merge-rules.yml
+++ b/workflows/reusable/merge-rules.yml
@@ -1,4 +1,4 @@
-# Merge Rules — Reusable Workflow (DOCUMENTATION COPY)
+# Merge Rules — Reusable Workflow
 #
 # This file is a documentation reference. The ACTUAL callable reusable workflow is:
 #   .github/workflows/merge-rules.yml
@@ -12,6 +12,7 @@
 #       with:
 #         require-linear-history: true
 #         commitlint-enabled: true
+#         branch-check-enabled: true
 #
 # Authentication: uses GITHUB_TOKEN automatically. No secrets need to be passed.
 # The caller must declare: permissions: contents: read, pull-requests: read

--- a/workflows/reusable/pr-automation.yml
+++ b/workflows/reusable/pr-automation.yml
@@ -1,4 +1,4 @@
-# PR Automation — Reusable Workflow (DOCUMENTATION COPY)
+# PR Automation — Reusable Workflow
 #
 # This file is a documentation reference. The ACTUAL callable reusable workflow is:
 #   .github/workflows/pr-automation.yml


### PR DESCRIPTION
## Summary

Closes #7

Enforces the rule that every PR must be linked to an issue via a properly named branch. Automates project board card movement so status tracks work in real-time.

## What changed

### `.github/workflows/merge-rules.yml`
- New `branch-name` job validates branch follows `type/ISSUE-slug` (e.g. `feat/42-add-oauth`)
- Bots (`dependabot/*`, `renovate/*`) and base branches (`main`, `develop`, etc.) are exempt
- Fixed duplicate `core.warning` block in the `squash-check` job
- New `branch-check-enabled` input for consumer repos to opt out

### `.github/workflows/project-automation.yml` (new)
Dual-trigger workflow that moves the linked issue card automatically:


| Event | Board status |
|-------|-------------|
| Branch pushed with issue number | **In Progress** |
| PR opened | **In Review** + repo owner auto-assigned as reviewer |
| PR approved | **Done** |

Requires a `GH_PROJECT_TOKEN` repository secret (fine-grained PAT with Projects write).

### `instructions/base.md`
- Branch strategy section now mandates issue-linked branches with the full naming format
- Pull requests section now requires `Closes #N` / `Fixes #N` in PR body
- New **Project board lifecycle** table documents the automated status transitions

### `composed/*`
Regenerated from updated `base.md`.
