### PR TITLE
feat(review): add stack-specific code review instruction files

### DIFF
--- a/instructions/code-review-csharp.instructions.md
+++ b/instructions/code-review-csharp.instructions.md
@@ -1,0 +1,63 @@
+---
+applyTo: "**/*.cs"
+---
+
+# C# Code Review Checklist
+
+> Stack-specific additions to the base `code-review.instructions.md`. Flag any violation as blocking unless marked **(nit)**.
+
+---
+
+## Async / threading
+
+- [ ] Every `async` method accepts a `CancellationToken` parameter and propagates it to all awaitable calls. Omitting it is a blocking violation.
+- [ ] No `async void` methods except event handlers. Use `async Task` and propagate exceptions properly.
+- [ ] No `.Result`, `.Wait()`, or `.GetAwaiter().GetResult()` — these block threads and cause deadlocks in ASP.NET's synchronization context.
+- [ ] `await` is used for all `Task`-returning calls — no fire-and-forget without explicit `_ = Task.Run(...)` and error handling.
+- [ ] In library code (not application code): `ConfigureAwait(false)` is applied on all awaits to avoid capturing the synchronization context.
+
+## Null safety
+
+- [ ] Nullable reference types are enabled (`<Nullable>enable</Nullable>`). No new `#nullable disable` suppressions without justification.
+- [ ] `ArgumentNullException.ThrowIfNull(param)` (or `ArgumentException.ThrowIfNullOrWhiteSpace` for strings) guards all public method parameters.
+- [ ] No `!` null-forgiving operators without a comment explaining why null is structurally impossible.
+
+## Resource management
+
+- [ ] All `IDisposable` / `IAsyncDisposable` objects are disposed via `using` declarations or `await using` — no manual `try/finally` wrapping.
+- [ ] No `HttpClient` instantiated directly with `new` — use `IHttpClientFactory`.
+- [ ] Database contexts (`DbContext`) are scoped per request and not held as singletons.
+
+## Configuration and DI
+
+- [ ] `IOptions<T>` or `IOptionsSnapshot<T>` is used to consume structured configuration — not `IConfiguration["Key"]` inline.
+- [ ] No `ServiceLocator` pattern (no `IServiceProvider.GetService<T>()` at call sites) — inject dependencies through constructors.
+- [ ] `record` types are used for immutable DTOs, command/query objects, and configuration models.
+
+## Error handling
+
+- [ ] Exceptions are used for exceptional conditions, not for normal control flow.
+- [ ] Domain errors (e.g., "entity not found", "validation failed") use a `Result<T>` or discriminated union (e.g., `ErrorOr<T>`, `OneOf<T, E>`) rather than throwing.
+- [ ] ASP.NET endpoints do not catch exceptions per-handler — centralized middleware with `ProblemDetails` is used.
+- [ ] `ILogger<T>` is used for all logging. No `Console.WriteLine` in production code.
+
+## EF Core
+
+- [ ] Read-only queries use `.AsNoTracking()` — tracked queries are reserved for operations that will call `SaveChanges`.
+- [ ] No raw SQL string concatenation — use `FromSqlRaw` with parameters or `FromSqlInterpolated`.
+- [ ] Migrations are code-first and committed to the repo — no pending model changes without a corresponding migration file.
+- [ ] N+1 query patterns are avoided: related entities are loaded with `.Include()` / `.ThenInclude()` or explicit projections.
+
+## Health and observability
+
+- [ ] Services expose a `/health` endpoint via `IHealthCheck` registrations.
+- [ ] Structured logging with `ILogger<T>` uses message templates (not string interpolation): `_logger.LogInformation("Processing {OrderId}", orderId)`.
+- [ ] `Activity` / OpenTelemetry spans are added for non-trivial operations (optional for small services, **(nit)**).
+
+## Testing
+
+- [ ] xUnit is used. Test methods follow `MethodName_Should_ExpectedBehavior_When_Condition` naming.
+- [ ] `FluentAssertions` is used for readable assertions.
+- [ ] `Testcontainers` (not SQLite in-memory) is used for integration tests that depend on a real database.
+- [ ] ASP.NET integration tests use `WebApplicationFactory<T>` — not hand-rolled HTTP clients.
+- [ ] Parameterized cases use `[Theory]` with `[InlineData]` or `[MemberData]` — no copy-pasted `[Fact]` methods.

--- a/instructions/code-review-python.instructions.md
+++ b/instructions/code-review-python.instructions.md
@@ -27,7 +27,7 @@ applyTo: "**/*.py"
 ## Async
 
 - [ ] `async def` is used at every IO boundary (network, filesystem, database).
-- [ ] No `asyncio.sleep(0)` used as a yield — use `asyncio.sleep(0)` only when intentional cooperative yield is needed.
+- [ ] `asyncio.sleep(0)` is only used for an intentional cooperative yield; it must not appear as an incidental placeholder or workaround for missing `await` chains.
 - [ ] `asyncio.gather` or `TaskGroup` (Python 3.11+) is used for concurrent tasks, not sequential `await` chains.
 - [ ] No blocking calls (e.g., `time.sleep`, sync file IO, `requests.get`) inside `async def` functions.
 

--- a/instructions/code-review-python.instructions.md
+++ b/instructions/code-review-python.instructions.md
@@ -1,0 +1,56 @@
+---
+applyTo: "**/*.py"
+---
+
+# Python Code Review Checklist
+
+> Stack-specific additions to the base `code-review.instructions.md`. Flag any violation as blocking unless marked **(nit)**.
+
+---
+
+## Type safety
+
+- [ ] All public function signatures have type annotations (parameters and return type).
+- [ ] `mypy --strict` or `pyright` in strict mode passes with no errors — type hints without a checker are decoration.
+- [ ] No use of `Any` without a `# type: ignore` comment explaining why it is unavoidable.
+- [ ] `from __future__ import annotations` is present in files that use forward references.
+
+## Python-specific correctness
+
+- [ ] No mutable default arguments (`def f(items=[])` or `def f(cfg={})`). Use `None` and assign inside the function body.
+- [ ] No bare `except:` — always catch a specific exception type.
+- [ ] `raise ... from err` is used when re-raising to preserve the exception chain.
+- [ ] No wildcard imports (`from module import *`).
+- [ ] All public packages define `__all__` to explicitly declare their public API.
+- [ ] Context managers (`with`) are used for all resources: files, DB sessions, HTTP clients, locks.
+
+## Async
+
+- [ ] `async def` is used at every IO boundary (network, filesystem, database).
+- [ ] No `asyncio.sleep(0)` used as a yield — use `asyncio.sleep(0)` only when intentional cooperative yield is needed.
+- [ ] `asyncio.gather` or `TaskGroup` (Python 3.11+) is used for concurrent tasks, not sequential `await` chains.
+- [ ] No blocking calls (e.g., `time.sleep`, sync file IO, `requests.get`) inside `async def` functions.
+
+## Code style (Ruff)
+
+- [ ] Ruff passes with no warnings. Rule groups `S` (security), `B` (bugbear), `UP` (pyupgrade), `SIM` (simplify), `PT` (pytest), `C4` (comprehensions), `A` (builtins), `N` (naming) are enabled.
+- [ ] No f-string usage of `%` or `.format()` for new code.
+- [ ] `pathlib.Path` is used instead of `os.path` for filesystem operations.
+
+## Logging and observability
+
+- [ ] `logging` (or `structlog`) is used — no `print()` statements in production code paths.
+- [ ] Log messages include enough context (IDs, operation name) without logging PII or secrets.
+- [ ] Exceptions are logged with `logger.exception()` (not `logger.error()`) to capture the stack trace.
+
+## Configuration
+
+- [ ] Environment variables are validated at application startup via `pydantic-settings` or equivalent — not read raw from `os.environ` inline.
+- [ ] No hardcoded magic strings or config values that should be env vars.
+
+## Testing
+
+- [ ] Test functions follow the `test_<behavior>_when_<condition>` naming pattern.
+- [ ] Fixtures are used for shared setup; `parametrize` is used for input variation, not copy-pasted test functions.
+- [ ] `pytest-mock` or `unittest.mock` is used to mock external dependencies — no real network/DB calls in unit tests.
+- [ ] Coverage has not regressed for the changed module.

--- a/instructions/code-review-typescript.instructions.md
+++ b/instructions/code-review-typescript.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "**/*.ts,**/*.tsx"
+applyTo: "**/*.{ts,tsx}"
 ---
 
 # TypeScript Code Review Checklist

--- a/instructions/code-review-typescript.instructions.md
+++ b/instructions/code-review-typescript.instructions.md
@@ -1,0 +1,59 @@
+---
+applyTo: "**/*.ts,**/*.tsx"
+---
+
+# TypeScript Code Review Checklist
+
+> Stack-specific additions to the base `code-review.instructions.md`. Flag any violation as blocking unless marked **(nit)**.
+
+---
+
+## Type safety
+
+- [ ] TypeScript strict mode is active (`"strict": true` in `tsconfig.json`). No exceptions have been added.
+- [ ] No `any` usage without a `// eslint-disable-next-line` comment with justification.
+- [ ] `unknown` is used instead of `any` where the type is genuinely unknown; narrowed before use.
+- [ ] No non-null assertions (`!`) without a comment explaining why null is impossible here.
+- [ ] `interface` is used for shapes that can be extended; `type` for unions, intersections, and mapped types.
+
+## Runtime validation
+
+- [ ] All external inputs (HTTP request bodies, query params, env vars, API responses) are validated with Zod (or equivalent) at the boundary — TypeScript types alone do not protect against runtime shape violations.
+- [ ] Zod schemas are co-located with the route/handler that uses them, not spread across the codebase.
+- [ ] Environment variables are validated at startup via a Zod schema (e.g., `t3-env`) — no raw `process.env.THING` access at call sites.
+
+## Async and error handling
+
+- [ ] All `async` functions are properly `await`ed — no floating promises.
+- [ ] `catch (error: unknown)` is used; the error is narrowed before access (`instanceof Error` or Zod safeParse).
+- [ ] No mixing of callbacks and Promises in the same flow.
+- [ ] Recoverable errors (e.g., "user not found") use a `Result<T, E>` type (e.g., `neverthrow`) rather than throwing exceptions.
+- [ ] States are modeled as discriminated unions (`{ status: 'loading' } | { status: 'error'; error: Error } | { status: 'success'; data: T }`) — not as combinations of nullable fields or boolean flags.
+
+## Code style (ESLint + Prettier)
+
+- [ ] ESLint passes with no warnings (`@typescript-eslint/recommended` baseline).
+- [ ] Prettier formatting is applied.
+- [ ] Named exports are used — default exports only where a framework requires them.
+- [ ] `const` is used throughout; no `let` unless mutation is required; no `var`.
+- [ ] `async/await` is used — no raw `.then().catch()` chains.
+
+## Logging and observability
+
+- [ ] `pino` (or equivalent structured logger) is used for Node.js services — no `console.log` in production paths.
+- [ ] Log messages include correlation/request IDs without logging PII, tokens, or full request bodies.
+- [ ] Errors logged include the `err` field (pino convention) for stack traces.
+
+## Module and build hygiene
+
+- [ ] `moduleResolution` in `tsconfig.json` is set to `bundler` or `NodeNext` — not the legacy `node` default.
+- [ ] New dependencies are added to `devDependencies` when they are build/test-only tools.
+- [ ] No circular imports introduced.
+- [ ] Barrel files (`index.ts`) are only added at intentional module boundaries.
+
+## Testing
+
+- [ ] Vitest is used for new test files (`vi.mock`, `vi.spyOn`, `@vitest/coverage-v8`).
+- [ ] Unit tests mock external dependencies with `vi.mock()` — no real HTTP calls or DB queries.
+- [ ] Integration tests use `supertest` + Testcontainers for real infrastructure.
+- [ ] E2E tests are in `e2e/` and run against a deployed/preview environment, not localhost.

--- a/instructions/code-review.instructions.md
+++ b/instructions/code-review.instructions.md
@@ -1,3 +1,7 @@
+---
+applyTo: "**"
+---
+
 # Code Review Instructions
 
 > Used by Copilot as a pre-PR automated checklist. Place this file (or include its contents) in `.github/` as `code-review.instructions.md`.

--- a/scripts/onboard-repo.sh
+++ b/scripts/onboard-repo.sh
@@ -75,10 +75,16 @@ mkdir -p "$REPO_PATH/.github"
 cp "$COMPOSED_FILE" "$REPO_PATH/.github/copilot-instructions.md"
 echo "  ✓ .github/copilot-instructions.md"
 
-# 2. Code review instructions
+# 2. Code review instructions (generic + stack-specific)
 if [ -f "$ROOT_DIR/instructions/code-review.instructions.md" ]; then
   cp "$ROOT_DIR/instructions/code-review.instructions.md" "$REPO_PATH/.github/code-review.instructions.md"
   echo "  ✓ .github/code-review.instructions.md"
+fi
+
+STACK_REVIEW="$ROOT_DIR/instructions/code-review-${STACK}.instructions.md"
+if [ -f "$STACK_REVIEW" ]; then
+  cp "$STACK_REVIEW" "$REPO_PATH/.github/code-review-${STACK}.instructions.md"
+  echo "  ✓ .github/code-review-${STACK}.instructions.md"
 fi
 
 # 3. PR templates

--- a/scripts/onboard-repo.sh
+++ b/scripts/onboard-repo.sh
@@ -7,7 +7,7 @@
 #
 # What it does:
 #   1. Copies the composed copilot-instructions.md to .github/
-#   2. Copies code-review.instructions.md to .github/
+#   2. Copies code-review.instructions.md and stack-specific code-review-<stack>.instructions.md to .github/
 #   3. Copies PR templates to .github/PULL_REQUEST_TEMPLATE/
 #   4. Copies the pull-standards sync workflow to .github/workflows/
 #   5. Copies MCP config if one exists for the stack


### PR DESCRIPTION
Adds stack-specific code review instruction files for Python, TypeScript, and C#.

## Changes

- Add applyTo frontmatter to generic code-review.instructions.md so VS Code auto-applies it
- Add instructions/code-review-python.instructions.md covering: strict type checking, Ruff rule groups, mutable defaults, __all__, async patterns, structlog, pydantic-settings
- Add instructions/code-review-typescript.instructions.md covering: Zod at all API boundaries, env var validation, pino logging, Result types, discriminated unions, Vitest
- Add instructions/code-review-csharp.instructions.md covering: CancellationToken in every async signature, no async void, no .Result/.Wait(), IOptions configuration, EF Core AsNoTracking, health checks
- Update onboard-repo.sh to copy the stack-specific review file alongside the generic one

Closes #11
