### PR TITLE
feat(infra): add csharp MCP config, dependabot template, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ CI runs `scripts/validate-composed.sh` to ensure composed files are never stale:
 
 ## Supported stacks
 
-| Stack | Instruction file | MCP config |
-|-------|-----------------|------------|
-| TypeScript | `instructions/stacks/typescript.md` | `mcp/typescript.mcp.json` |
-| Python | `instructions/stacks/python.md` | `mcp/python.mcp.json` |
-| C# | `instructions/stacks/csharp.md` | — |
+| Stack | Instruction file | Code review checklist | MCP config |
+|-------|-----------------|----------------------|------------|
+| TypeScript | `instructions/stacks/typescript.md` | `instructions/code-review-typescript.instructions.md` | `mcp/typescript.mcp.json` |
+| Python | `instructions/stacks/python.md` | `instructions/code-review-python.instructions.md` | `mcp/python.mcp.json` |
+| C# | `instructions/stacks/csharp.md` | `instructions/code-review-csharp.instructions.md` | `mcp/csharp.mcp.json` |
 
 ## Workflows
 

--- a/mcp/csharp.mcp.json
+++ b/mcp/csharp.mcp.json
@@ -1,0 +1,15 @@
+{
+  "servers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${input:github-token}"
+      }
+    },
+    "memory": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-memory"]
+    }
+  }
+}

--- a/scripts/onboard-repo.sh
+++ b/scripts/onboard-repo.sh
@@ -107,9 +107,10 @@ if [ -f "$MCP_FILE" ]; then
   echo "  ✓ .vscode/mcp.json"
 fi
 
-# 6. Dependabot config (only if target repo doesn't already have one)
+# 6. Dependabot config (only if target repo doesn't already have one — idempotent)
 DEPENDABOT_TMPL="$ROOT_DIR/templates/dependabot.yml"
 if [ -f "$DEPENDABOT_TMPL" ] && [ ! -f "$REPO_PATH/.github/dependabot.yml" ]; then
+  mkdir -p "$REPO_PATH/.github"
   cp "$DEPENDABOT_TMPL" "$REPO_PATH/.github/dependabot.yml"
   echo "  ✓ .github/dependabot.yml"
 fi

--- a/scripts/onboard-repo.sh
+++ b/scripts/onboard-repo.sh
@@ -97,6 +97,7 @@ echo "  ✓ .github/workflows/pull-standards.yml"
 # 5. MCP config
 MCP_FILE="$ROOT_DIR/mcp/${STACK}.mcp.json"
 if [ -f "$MCP_FILE" ]; then
+  mkdir -p "$REPO_PATH/.vscode"
   # Merge with base MCP config
   if command -v jq > /dev/null 2>&1 && [ -f "$ROOT_DIR/mcp/base.mcp.json" ]; then
     jq -s '.[0] * .[1]' "$ROOT_DIR/mcp/base.mcp.json" "$MCP_FILE" > "$REPO_PATH/.vscode/mcp.json"
@@ -104,6 +105,13 @@ if [ -f "$MCP_FILE" ]; then
     cp "$MCP_FILE" "$REPO_PATH/.vscode/mcp.json"
   fi
   echo "  ✓ .vscode/mcp.json"
+fi
+
+# 6. Dependabot config (only if target repo doesn't already have one)
+DEPENDABOT_TMPL="$ROOT_DIR/templates/dependabot.yml"
+if [ -f "$DEPENDABOT_TMPL" ] && [ ! -f "$REPO_PATH/.github/dependabot.yml" ]; then
+  cp "$DEPENDABOT_TMPL" "$REPO_PATH/.github/dependabot.yml"
+  echo "  ✓ .github/dependabot.yml"
 fi
 
 echo ""

--- a/templates/dependabot.yml
+++ b/templates/dependabot.yml
@@ -2,6 +2,9 @@ version: 2
 
 updates:
   # Keep GitHub Actions up to date automatically.
+  # versioning-strategy is not applicable to github-actions (Dependabot always pins to the latest
+  # available SHA/tag for the major version). For package ecosystems below, set
+  # versioning-strategy to "increase" (bump minimum) or "lockfile-only" (only update lockfile).
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -28,6 +31,7 @@ updates:
   #   schedule:
   #     interval: "weekly"
   #     day: "monday"
+  #   versioning-strategy: "increase"   # bump minimum required version in package.json
   #   commit-message:
   #     prefix: "chore(deps)"
   #   open-pull-requests-limit: 10
@@ -43,6 +47,7 @@ updates:
   #   schedule:
   #     interval: "weekly"
   #     day: "monday"
+  #   versioning-strategy: "increase"   # bump minimum version in pyproject.toml / requirements
   #   commit-message:
   #     prefix: "chore(deps)"
   #   open-pull-requests-limit: 10
@@ -53,6 +58,7 @@ updates:
   #   schedule:
   #     interval: "weekly"
   #     day: "monday"
+  #   versioning-strategy: "increase"   # bump minimum version in .csproj / Directory.Packages.props
   #   commit-message:
   #     prefix: "chore(deps)"
   #   open-pull-requests-limit: 10

--- a/templates/dependabot.yml
+++ b/templates/dependabot.yml
@@ -1,0 +1,58 @@
+version: 2
+
+updates:
+  # Keep GitHub Actions up to date automatically.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    labels:
+      - "chore"
+      - "dependencies"
+    commit-message:
+      prefix: "chore(ci)"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Uncomment and adjust for your stack:
+
+  # npm / pnpm
+  # - package-ecosystem: "npm"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #     day: "monday"
+  #   commit-message:
+  #     prefix: "chore(deps)"
+  #   open-pull-requests-limit: 10
+  #   groups:
+  #     production-deps:
+  #       dependency-type: "production"
+  #     dev-deps:
+  #       dependency-type: "development"
+
+  # pip / uv / poetry
+  # - package-ecosystem: "pip"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #     day: "monday"
+  #   commit-message:
+  #     prefix: "chore(deps)"
+  #   open-pull-requests-limit: 10
+
+  # nuget
+  # - package-ecosystem: "nuget"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #     day: "monday"
+  #   commit-message:
+  #     prefix: "chore(deps)"
+  #   open-pull-requests-limit: 10


### PR DESCRIPTION
Infrastructure completions to make the standards repo consistent and immediately usable across all stacks.

## Changes

- Add mcp/csharp.mcp.json: C# now has MCP config (github + memory servers), consistent with python and typescript
- Add templates/dependabot.yml: commented ecosystem scaffold for npm/pip/nuget; auto-copied by onboard-repo.sh to new repos
- Update onboard-repo.sh: distribute dependabot.yml to target repos (skipped if already present); also includes the .vscode mkdir fix from #10
- Update README: add code-review-<stack> column to supported stacks table; fix C# MCP column from dash to filename

Closes #14
