### PR TITLE
chore(instructions): tighten section headings and add Python exception logging rule

### DIFF
--- a/composed/csharp-copilot-instructions.md
+++ b/composed/csharp-copilot-instructions.md
@@ -193,7 +193,7 @@ Every issue moves through these statuses automatically via CI:
 - Use `ILogger<T>` for structured logging with message templates: `_logger.LogInformation("Processing {OrderId}", orderId)`. Never use `Console.WriteLine` or string interpolation in log calls.
 - In ASP.NET, use global exception-handling middleware returning RFC 7807 `ProblemDetails` responses. Do not scatter `try/catch` in every endpoint.
 
-## EF Core data access patterns
+## EF Core
 
 - Use `.AsNoTracking()` on all read-only queries. Tracked queries are reserved for operations that call `SaveChangesAsync`.
 - Never build queries with raw string concatenation. Use `FromSqlRaw` with parameters or `FromSqlInterpolated`.

--- a/composed/python-copilot-instructions.md
+++ b/composed/python-copilot-instructions.md
@@ -169,7 +169,7 @@ Every issue moves through these statuses automatically via CI:
 - Maximum line length: 88 characters (Ruff/Black default).
 - Use `snake_case` for functions and variables, `PascalCase` for classes, `UPPER_SNAKE_CASE` for constants.
 
-## Async and concurrency
+## Async
 
 - Use `asyncio` for IO-bound concurrency. Define `async def` at every IO boundary (network, filesystem, database).
 - Use `asyncio.TaskGroup` (Python 3.11+) or `asyncio.gather` for concurrent tasks — do not `await` IO calls sequentially when they can run in parallel.
@@ -180,6 +180,7 @@ Every issue moves through these statuses automatically via CI:
 - Define custom exception classes inheriting from a project-level base exception.
 - Never use bare `except:`. Always catch specific exception types.
 - Use `raise ... from err` to preserve exception chains.
+- Log exceptions with `logger.exception()` to capture stack traces.
 
 ## Logging and observability
 

--- a/instructions/stacks/csharp.md
+++ b/instructions/stacks/csharp.md
@@ -53,7 +53,7 @@
 - Use `ILogger<T>` for structured logging with message templates: `_logger.LogInformation("Processing {OrderId}", orderId)`. Never use `Console.WriteLine` or string interpolation in log calls.
 - In ASP.NET, use global exception-handling middleware returning RFC 7807 `ProblemDetails` responses. Do not scatter `try/catch` in every endpoint.
 
-## EF Core data access patterns
+## EF Core
 
 - Use `.AsNoTracking()` on all read-only queries. Tracked queries are reserved for operations that call `SaveChangesAsync`.
 - Never build queries with raw string concatenation. Use `FromSqlRaw` with parameters or `FromSqlInterpolated`.

--- a/instructions/stacks/python.md
+++ b/instructions/stacks/python.md
@@ -29,7 +29,7 @@
 - Maximum line length: 88 characters (Ruff/Black default).
 - Use `snake_case` for functions and variables, `PascalCase` for classes, `UPPER_SNAKE_CASE` for constants.
 
-## Async and concurrency
+## Async
 
 - Use `asyncio` for IO-bound concurrency. Define `async def` at every IO boundary (network, filesystem, database).
 - Use `asyncio.TaskGroup` (Python 3.11+) or `asyncio.gather` for concurrent tasks — do not `await` IO calls sequentially when they can run in parallel.
@@ -40,6 +40,7 @@
 - Define custom exception classes inheriting from a project-level base exception.
 - Never use bare `except:`. Always catch specific exception types.
 - Use `raise ... from err` to preserve exception chains.
+- Log exceptions with `logger.exception()` to capture stack traces.
 
 ## Logging and observability
 


### PR DESCRIPTION
Closes #32

## Changes

### `instructions/stacks/csharp.md`
- Rename `## EF Core data access patterns` → `## EF Core` for consistency with other section headings.

### `instructions/stacks/python.md`
- Rename `## Async and concurrency` → `## Async`.
- Add missing rule to the Error handling section: *Log exceptions with `logger.exception()` to capture stack traces.* This rule existed in the code-review checklist but was absent from the authoritative stack instructions.

### `composed/`
- Regenerate `csharp-copilot-instructions.md` and `python-copilot-instructions.md` to reflect the above source changes. All files pass `validate-composed.sh`.