### PR TITLE
fix(workflows): fix invalid env context and duplicate permissions in project-automation

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -78,8 +78,8 @@ jobs:
               return;
             }
 
-            const PROJECT_OWNER  = '${{ inputs.project-owner  || env.PROJECT_OWNER  }}' || context.repo.owner;
-            const PROJECT_NUMBER = parseInt('${{ inputs.project-number || env.PROJECT_NUMBER }}' || '4', 10);
+            const PROJECT_OWNER  = '${{ inputs.project-owner }}' || context.repo.owner;
+            const PROJECT_NUMBER = parseInt('${{ inputs.project-number }}' || '4', 10);
 
             const issue = context.payload.issue;
             const issueNodeId = issue.node_id;
@@ -157,8 +157,8 @@ jobs:
               return;
             }
 
-            const PROJECT_OWNER  = '${{ inputs.project-owner  || env.PROJECT_OWNER  }}' || context.repo.owner;
-            const PROJECT_NUMBER = parseInt('${{ inputs.project-number || env.PROJECT_NUMBER }}' || '4', 10);
+            const PROJECT_OWNER  = '${{ inputs.project-owner }}' || context.repo.owner;
+            const PROJECT_NUMBER = parseInt('${{ inputs.project-number }}' || '4', 10);
 
             const branch = context.ref.replace('refs/heads/', '');
 
@@ -253,9 +253,9 @@ jobs:
               return;
             }
 
-            const PROJECT_OWNER  = '${{ inputs.project-owner  || env.PROJECT_OWNER  }}' || context.repo.owner;
-            const PROJECT_NUMBER = parseInt('${{ inputs.project-number || env.PROJECT_NUMBER }}' || '4', 10);
-            const REPO_OWNER     = '${{ inputs.repo-owner     || env.REPO_OWNER     }}' || context.repo.owner;
+            const PROJECT_OWNER  = '${{ inputs.project-owner }}' || context.repo.owner;
+            const PROJECT_NUMBER = parseInt('${{ inputs.project-number }}' || '4', 10);
+            const REPO_OWNER     = '${{ inputs.repo-owner }}' || context.repo.owner;
 
             const pr       = context.payload.pull_request;
             const prNumber = pr.number;
@@ -369,10 +369,6 @@ jobs:
       contents: write      # required for enablePullRequestAutoMerge
       pull-requests: write # required for enablePullRequestAutoMerge
       issues: read
-    permissions:
-      contents: write      # required for enablePullRequestAutoMerge
-      pull-requests: write # required for enablePullRequestAutoMerge
-      issues: read
     steps:
       - name: Move linked issues to Done
         uses: actions/github-script@v9
@@ -384,8 +380,8 @@ jobs:
               return;
             }
 
-            const PROJECT_OWNER  = '${{ inputs.project-owner  || env.PROJECT_OWNER  }}' || context.repo.owner;
-            const PROJECT_NUMBER = parseInt('${{ inputs.project-number || env.PROJECT_NUMBER }}' || '4', 10);
+            const PROJECT_OWNER  = '${{ inputs.project-owner }}' || context.repo.owner;
+            const PROJECT_NUMBER = parseInt('${{ inputs.project-number }}' || '4', 10);
 
             const body   = context.payload.pull_request.body ?? '';
             const branch = context.payload.pull_request.head.ref;


### PR DESCRIPTION
## What changed

- Replaced all `inputs.X || env.X` patterns with direct `inputs.X` references across all four jobs in project-automation.yml.
- Removed the duplicate `permissions` block from the `approval-to-done` job.

## Why

The `env.PROJECT_OWNER`, `env.PROJECT_NUMBER`, and `env.REPO_OWNER` variables are never set anywhere in the workflow, so the fallback always resolved to empty string. The validator also flagged the duplicate permissions block as a YAML error.

Closes #28