### PR TITLE
feat(instructions): enforce agentic workflow via base.md

### DIFF
--- a/composed/csharp-copilot-instructions.md
+++ b/composed/csharp-copilot-instructions.md
@@ -18,6 +18,18 @@ These are universal rules that apply to **every** repository regardless of langu
 - Do not leave dead code, commented-out code, or TODO comments without a linked issue.
 - Treat compiler/linter warnings as errors.
 
+
+## Agentic workflow
+
+Before making any code change, always execute these steps in order:
+
+1. **Create a GitHub issue** describing the problem or feature. Use `gh issue create` with a clear title and body.
+2. **Create a branch** from `main` following the naming format `<type>/<issue-number>-<short-slug>` (e.g. `feat/42-add-oauth-flow`). Use `git checkout -b`.
+3. **Make the changes** on that branch — never commit directly to `main`.
+4. **Open a PR** that references the issue with `Closes #N` in the body.
+
+Do not skip or defer any of these steps, even for small or "obvious" fixes.
+
 ## Branch strategy
 
 - **`main`** is the default, protected branch. All changes merge into `main` via pull request.

--- a/composed/python-copilot-instructions.md
+++ b/composed/python-copilot-instructions.md
@@ -18,6 +18,7 @@ These are universal rules that apply to **every** repository regardless of langu
 - Do not leave dead code, commented-out code, or TODO comments without a linked issue.
 - Treat compiler/linter warnings as errors.
 
+
 ## Agentic workflow
 
 Before making any code change, always execute these steps in order:

--- a/composed/python-copilot-instructions.md
+++ b/composed/python-copilot-instructions.md
@@ -18,6 +18,17 @@ These are universal rules that apply to **every** repository regardless of langu
 - Do not leave dead code, commented-out code, or TODO comments without a linked issue.
 - Treat compiler/linter warnings as errors.
 
+## Agentic workflow
+
+Before making any code change, always execute these steps in order:
+
+1. **Create a GitHub issue** describing the problem or feature. Use `gh issue create` with a clear title and body.
+2. **Create a branch** from `main` following the naming format `<type>/<issue-number>-<short-slug>` (e.g. `feat/42-add-oauth-flow`). Use `git checkout -b`.
+3. **Make the changes** on that branch — never commit directly to `main`.
+4. **Open a PR** that references the issue with `Closes #N` in the body.
+
+Do not skip or defer any of these steps, even for small or "obvious" fixes.
+
 ## Branch strategy
 
 - **`main`** is the default, protected branch. All changes merge into `main` via pull request.

--- a/composed/typescript-copilot-instructions.md
+++ b/composed/typescript-copilot-instructions.md
@@ -18,6 +18,7 @@ These are universal rules that apply to **every** repository regardless of langu
 - Do not leave dead code, commented-out code, or TODO comments without a linked issue.
 - Treat compiler/linter warnings as errors.
 
+
 ## Agentic workflow
 
 Before making any code change, always execute these steps in order:

--- a/composed/typescript-copilot-instructions.md
+++ b/composed/typescript-copilot-instructions.md
@@ -18,6 +18,17 @@ These are universal rules that apply to **every** repository regardless of langu
 - Do not leave dead code, commented-out code, or TODO comments without a linked issue.
 - Treat compiler/linter warnings as errors.
 
+## Agentic workflow
+
+Before making any code change, always execute these steps in order:
+
+1. **Create a GitHub issue** describing the problem or feature. Use `gh issue create` with a clear title and body.
+2. **Create a branch** from `main` following the naming format `<type>/<issue-number>-<short-slug>` (e.g. `feat/42-add-oauth-flow`). Use `git checkout -b`.
+3. **Make the changes** on that branch — never commit directly to `main`.
+4. **Open a PR** that references the issue with `Closes #N` in the body.
+
+Do not skip or defer any of these steps, even for small or "obvious" fixes.
+
 ## Branch strategy
 
 - **`main`** is the default, protected branch. All changes merge into `main` via pull request.

--- a/instructions/base.md
+++ b/instructions/base.md
@@ -14,6 +14,18 @@ These are universal rules that apply to **every** repository regardless of langu
 - Do not leave dead code, commented-out code, or TODO comments without a linked issue.
 - Treat compiler/linter warnings as errors.
 
+
+## Agentic workflow
+
+Before making any code change, always execute these steps in order:
+
+1. **Create a GitHub issue** describing the problem or feature. Use `gh issue create` with a clear title and body.
+2. **Create a branch** from `main` following the naming format `<type>/<issue-number>-<short-slug>` (e.g. `feat/42-add-oauth-flow`). Use `git checkout -b`.
+3. **Make the changes** on that branch — never commit directly to `main`.
+4. **Open a PR** that references the issue with `Closes #N` in the body.
+
+Do not skip or defer any of these steps, even for small or "obvious" fixes.
+
 ## Branch strategy
 
 - **`main`** is the default, protected branch. All changes merge into `main` via pull request.


### PR DESCRIPTION
## What changed

- Added an "Agentic workflow" section to `instructions/base.md` with four numbered imperative steps Copilot must follow before any code change: create issue, create branch, code, open PR.
- Regenerated `composed/csharp-copilot-instructions.md`, `composed/python-copilot-instructions.md`, and `composed/typescript-copilot-instructions.md` so all downstream stacks inherit the rule.

## Why

The process was described as reference documentation but not as an actionable instruction Copilot would follow. Moving it to base.md as imperative steps ensures it propagates to all consumer repos via the composed files.

Closes #30