### PR TITLE
feat(prompts): add task-based agent prompts for implement-feature, write-tests, fix-bug

### DIFF
--- a/.github/prompts/audit.prompt.md
+++ b/.github/prompts/audit.prompt.md
@@ -1,11 +1,11 @@
 ---
-mode: agent
+agent: agent
 description: "Senior Agentic Standards Auditor — run against any branch diff to validate compliance."
 ---
 
 # Senior Agentic Standards Audit
 
-## Step 1 — Generate the diff
+## Step 1 — Generate the branch diff for analysis
 
 ```bash
 git --no-pager diff main...HEAD > audit_diff.txt
@@ -94,7 +94,7 @@ Apply all fixes directly. Do not just report — fix.
 
 ---
 
-## Step 2 — Cleanup
+## Step 2 — Remove temporary audit artifacts
 
 ```bash
 rm audit_diff.txt

--- a/.github/prompts/fix-bug.prompt.md
+++ b/.github/prompts/fix-bug.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: agent
+agent: agent
 description: "Diagnose and fix a bug systematically: reproduce with a failing test, trace to the root cause, apply the minimal fix, add a regression test, and open a PR."
 ---
 
@@ -24,7 +24,7 @@ dotnet test --filter "Should_<Behaviour>_When_<Condition>"
 
 Do not proceed to Step 3 until this failing test exists.
 
-## Step 2 — Root-cause analysis
+## Step 2 — Identify the root cause before writing any fix
 
 Trace the execution path from the symptom to the root cause:
 
@@ -43,7 +43,7 @@ Trace the execution path from the symptom to the root cause:
 
 **Do not move to Step 3 until you can state the root cause clearly.**
 
-## Step 3 — Apply the minimal fix
+## Step 3 — Apply a targeted fix scoped to the confirmed root cause
 
 - Change **only** the code required to fix the root cause.
 - Do not refactor, rename, or clean up unrelated code in the same commit.
@@ -55,7 +55,7 @@ Trace the execution path from the symptom to the root cause:
 - Python: use `is None` checks; avoid bare `except`; use `raise ... from err` for chained exceptions.
 - C#: use `ArgumentNullException.ThrowIfNull()`; check `CancellationToken` propagation for async bugs.
 
-## Step 4 — Add / update tests
+## Step 4 — Confirm the fix holds and add regression coverage
 
 - The failing test from Step 1 must now pass.
 - Add tests for any **additional edge cases** surfaced during root-cause analysis.
@@ -69,7 +69,7 @@ vitest run
 dotnet test
 ```
 
-## Step 5 — Verify
+## Step 5 — Verify fix correctness and no regressions
 
 - [ ] The failing test from Step 1 now passes
 - [ ] No existing tests are broken
@@ -77,7 +77,7 @@ dotnet test
 - [ ] The fix does not introduce new linting errors: `ruff check` / `eslint` / `dotnet build -warnaserror`
 - [ ] The root cause is clearly understood (not just symptoms patched)
 
-## Step 6 — Commit and open a PR
+## Step 6 — Record the fix and open it for peer review
 
 ```bash
 git add -A

--- a/.github/prompts/fix-bug.prompt.md
+++ b/.github/prompts/fix-bug.prompt.md
@@ -1,0 +1,100 @@
+---
+mode: agent
+description: "Diagnose and fix a bug systematically: reproduce with a failing test, trace to the root cause, apply the minimal fix, add a regression test, and open a PR."
+---
+
+# Fix Bug
+
+You are a debugging agent. Never guess — always trace to the root cause before changing any code.
+
+## Step 1 — Reproduce before touching production code
+
+Write a **failing test** that demonstrates the bug first. This is non-negotiable.
+
+- The test should fail in the current state of the code.
+- The test should pass once the bug is fixed.
+- If the bug is non-deterministic (race condition, timing-dependent), note this and describe the reproduction conditions manually instead.
+
+```bash
+# Run only the new test to confirm it fails
+pytest tests/test_foo.py::test_should_<behaviour>_when_<condition> -v
+vitest run src/__tests__/foo.test.ts
+dotnet test --filter "Should_<Behaviour>_When_<Condition>"
+```
+
+Do not proceed to Step 3 until this failing test exists.
+
+## Step 2 — Root-cause analysis
+
+Trace the execution path from the symptom to the root cause:
+
+1. What is the observable symptom? (wrong output, exception thrown, no response, data corruption)
+2. Where in the call chain does the failure originate?
+3. What is the **root cause**? Choose one:
+   - Wrong assumption (precondition not validated)
+   - Missing guard (null/undefined/None not handled)
+   - Off-by-one or boundary error
+   - Race condition or incorrect async handling
+   - Incorrect type coercion / serialisation
+   - Logic error in a conditional
+   - Leaked state between requests / calls
+   - Dependency behaving unexpectedly (version change, config drift)
+4. Write the root cause in 1–3 sentences. You will include this in the PR description.
+
+**Do not move to Step 3 until you can state the root cause clearly.**
+
+## Step 3 — Apply the minimal fix
+
+- Change **only** the code required to fix the root cause.
+- Do not refactor, rename, or clean up unrelated code in the same commit.
+- If a refactor is needed to safely apply the fix, do it in a separate commit on the same branch.
+- Ensure the fix handles all variants of the bug (different inputs, edge cases, related code paths).
+
+**Stack-specific considerations**
+- TypeScript: check for `null` / `undefined` with proper narrowing — not `!` assertion.
+- Python: use `is None` checks; avoid bare `except`; use `raise ... from err` for chained exceptions.
+- C#: use `ArgumentNullException.ThrowIfNull()`; check `CancellationToken` propagation for async bugs.
+
+## Step 4 — Add / update tests
+
+- The failing test from Step 1 must now pass.
+- Add tests for any **additional edge cases** surfaced during root-cause analysis.
+- If the bug was in a code path with no existing tests, add unit coverage for the surrounding logic too.
+- Ensure the **full existing test suite** still passes — no regressions.
+
+```bash
+# Full suite
+pytest
+vitest run
+dotnet test
+```
+
+## Step 5 — Verify
+
+- [ ] The failing test from Step 1 now passes
+- [ ] No existing tests are broken
+- [ ] No debug logging (`console.log`, `print()`, `Debug.WriteLine()`) left in production code
+- [ ] The fix does not introduce new linting errors: `ruff check` / `eslint` / `dotnet build -warnaserror`
+- [ ] The root cause is clearly understood (not just symptoms patched)
+
+## Step 6 — Commit and open a PR
+
+```bash
+git add -A
+git commit -m "fix(<scope>): <what was wrong and what the fix does>
+
+Root cause: <1-sentence root cause>
+Fix: <1-sentence description of the change>
+
+Closes #<issue-number>"
+
+git push origin <branch-name>
+gh pr create \
+  --title "fix(<scope>): <description>" \
+  --body "Closes #<issue-number>"
+```
+
+**PR description must include:**
+- **Root cause** — what was wrong and why
+- **Fix applied** — what was changed
+- **How tested** — which failing test now passes, any additional coverage added

--- a/.github/prompts/governance.prompt.md
+++ b/.github/prompts/governance.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: agent
+agent: agent
 description: "Full governance workflow — execute before making any change to this repository."
 ---
 

--- a/.github/prompts/implement-feature.prompt.md
+++ b/.github/prompts/implement-feature.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: agent
+agent: agent
 description: "Implement a feature end-to-end: explore the issue, design a solution, write production code, add tests, self-review, and open a PR — all following project standards."
 ---
 
@@ -7,14 +7,14 @@ description: "Implement a feature end-to-end: explore the issue, design a soluti
 
 You are a software development agent. Work through the steps below in order. Do not skip steps.
 
-## Step 1 — Understand the scope
+## Step 1 — Understand feature scope and affected modules
 
 - Read the linked issue carefully. If acceptance criteria are missing or ambiguous, ask before writing any code.
 - Identify which stack(s) are involved (TypeScript, Python, C# — or a combination).
 - Identify the modules, services, or layers that need to change.
 - If the change could affect a public API contract, list the endpoints or types that will change.
 
-## Step 2 — Design before coding
+## Step 2 — Produce a written design plan before modifying any file
 
 Write 3–7 bullet points describing your approach before touching any files:
 
@@ -25,7 +25,7 @@ Write 3–7 bullet points describing your approach before touching any files:
 
 If the design requires an architectural decision, pause and create an ADR (in `docs/decisions/` or equivalent) before proceeding.
 
-## Step 3 — Implement
+## Step 3 — Implement following stack-specific standards
 
 Follow the copilot instructions for the relevant stack(s):
 
@@ -54,7 +54,7 @@ Follow the copilot instructions for the relevant stack(s):
 - No `.Result` / `.Wait()`.
 - `using` / `await using` for all `IDisposable`.
 
-## Step 4 — Write tests
+## Step 4 — Ensure feature is covered by unit, integration, and E2E tests
 
 Write tests **alongside** the implementation, not after.
 
@@ -80,7 +80,7 @@ Write tests **alongside** the implementation, not after.
 - TypeScript: `vitest` + `@vitest/coverage-v8` + `supertest`
 - C#: `xUnit` + `FluentAssertions` + `WebApplicationFactory<T>`
 
-## Step 5 — Self-review
+## Step 5 — Verify all acceptance criteria are met before committing
 
 Before committing, verify every item:
 
@@ -92,7 +92,7 @@ Before committing, verify every item:
 - [ ] All tests pass: `pytest` / `vitest run` / `dotnet test`
 - [ ] No untracked `TODO`s introduced without a linked issue
 
-## Step 6 — Commit and open a PR
+## Step 6 — Record the implementation and open it for peer review
 
 Follow the governance workflow:
 

--- a/.github/prompts/implement-feature.prompt.md
+++ b/.github/prompts/implement-feature.prompt.md
@@ -1,0 +1,116 @@
+---
+mode: agent
+description: "Implement a feature end-to-end: explore the issue, design a solution, write production code, add tests, self-review, and open a PR — all following project standards."
+---
+
+# Implement Feature
+
+You are a software development agent. Work through the steps below in order. Do not skip steps.
+
+## Step 1 — Understand the scope
+
+- Read the linked issue carefully. If acceptance criteria are missing or ambiguous, ask before writing any code.
+- Identify which stack(s) are involved (TypeScript, Python, C# — or a combination).
+- Identify the modules, services, or layers that need to change.
+- If the change could affect a public API contract, list the endpoints or types that will change.
+
+## Step 2 — Design before coding
+
+Write 3–7 bullet points describing your approach before touching any files:
+
+- What will you add / change / remove?
+- Where does the change live (layer, module, file)?
+- What new abstractions, if any, are introduced?
+- What are the main risks or edge cases?
+
+If the design requires an architectural decision, pause and create an ADR (in `docs/decisions/` or equivalent) before proceeding.
+
+## Step 3 — Implement
+
+Follow the copilot instructions for the relevant stack(s):
+
+**All stacks**
+- Validate all external inputs at the boundary — never deep inside business logic.
+  - TypeScript: Zod schema
+  - Python: Pydantic model
+  - C#: `ArgumentNullException.ThrowIfNull()` + FluentValidation / data annotations
+- Handle errors explicitly. No empty `catch` blocks. No silent swallowing.
+- Use structured logging — no `console.log`, `print()`, or `Debug.WriteLine()`.
+- No secrets or environment-specific values hardcoded in source.
+- No dead code. Remove stubs and `TODO`s that are not tracked as follow-up issues.
+
+**TypeScript**
+- `unknown` over `any`; `const`-first; named exports.
+- Async/await only — no `.then().catch()` chains.
+- `Result<T, E>` (neverthrow) for recoverable domain errors.
+
+**Python**
+- Type annotations on every function signature; passes `mypy --strict` / `pyright`.
+- `async def` at all I/O boundaries; no blocking calls inside `async def`.
+- Context managers (`with`) for all resources.
+
+**C#**
+- `CancellationToken` in every `async` method signature.
+- No `.Result` / `.Wait()`.
+- `using` / `await using` for all `IDisposable`.
+
+## Step 4 — Write tests
+
+Write tests **alongside** the implementation, not after.
+
+**Unit tests** (mock all external dependencies)
+- Happy path
+- Edge cases: empty input, nulls/undefined/None, boundary values
+- Error / exception paths
+- Test naming: `should <behaviour> when <condition>`
+  - Python: `test_<behaviour>_when_<condition>`
+  - TypeScript: `it('should <behaviour> when <condition>')`
+  - C#: `Should_<Behaviour>_When_<Condition>()`
+
+**Integration tests** (real infrastructure when possible)
+- One test per new API endpoint or significant use case.
+- Use Testcontainers for DB / queue dependencies — not in-memory fakes.
+
+**E2E tests** (critical user paths only)
+- Python / TypeScript: Playwright (`@playwright/test` or `playwright-pytest`)
+- Add to `e2e/` directory
+
+**Stack-specific tools**
+- Python: `pytest` + `pytest-mock` + `pytest-cov`
+- TypeScript: `vitest` + `@vitest/coverage-v8` + `supertest`
+- C#: `xUnit` + `FluentAssertions` + `WebApplicationFactory<T>`
+
+## Step 5 — Self-review
+
+Before committing, verify every item:
+
+- [ ] All acceptance criteria from the issue are satisfied
+- [ ] No `console.log` / `print()` / debug logging left in production code
+- [ ] No hardcoded secrets, tokens, or environment-specific URLs
+- [ ] All new / changed public APIs are documented (docstring / JSDoc / XML doc)
+- [ ] Linting passes: `ruff check` / `eslint` / `dotnet build -warnaserror`
+- [ ] All tests pass: `pytest` / `vitest run` / `dotnet test`
+- [ ] No untracked `TODO`s introduced without a linked issue
+
+## Step 6 — Commit and open a PR
+
+Follow the governance workflow:
+
+```bash
+git add -A
+git commit -m "feat(<scope>): <imperative description of what was added>
+
+<Optional: 2-3 sentences on why this approach was chosen>
+
+Closes #<issue-number>"
+
+git push origin <branch-name>
+gh pr create \
+  --title "feat(<scope>): <description>" \
+  --body "Closes #<issue-number>"
+```
+
+PR description must include:
+- What was implemented
+- Key design decisions made
+- How it was tested

--- a/.github/prompts/write-tests.prompt.md
+++ b/.github/prompts/write-tests.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: agent
+agent: agent
 description: "Write a comprehensive test suite for existing production code — covering unit, integration, and edge cases — using the conventions of the relevant stack."
 ---
 
@@ -22,7 +22,7 @@ Before writing any test, read the target module(s) and produce a coverage plan:
 
 Present this plan before writing the first test file.
 
-## Step 2 — Unit tests
+## Step 2 — Write isolated unit tests for all public interfaces
 
 **Rules for all stacks**
 - Mock **all** external dependencies — no real network calls, no real DB, no real filesystem.
@@ -84,7 +84,7 @@ result.Name.Should().Be("Alice");
 act.Should().ThrowAsync<NotFoundException>();
 ```
 
-## Step 3 — Integration tests (where appropriate)
+## Step 3 — Cover infrastructure boundaries with real-container integration tests
 
 Use integration tests for:
 - Database queries (SQL semantics, constraints, migrations)
@@ -101,7 +101,7 @@ Use integration tests for:
 - TypeScript: `testcontainers` npm package; use `supertest` for HTTP.
 - C#: `Testcontainers.PostgreSql` / `Testcontainers.MsSql`; `WebApplicationFactory<T>` for API tests.
 
-## Step 4 — Assert meaningfully
+## Step 4 — Assert on behaviour and side effects, not just truthiness
 
 Prefer:
 - Specific value assertions over `toBeTruthy()` / `Assert.True(x != null)`
@@ -113,7 +113,7 @@ Avoid:
 - Snapshots for logic tests (fragile, opaque failures)
 - `time.sleep` / `Thread.Sleep` in tests — use async patterns or test doubles for time
 
-## Step 5 — Validate
+## Step 5 — Validate test suite quality and completeness
 
 - [ ] All new tests pass: `pytest -x` / `vitest run` / `dotnet test`
 - [ ] No flaky async tests (all promises awaited, all async fixtures resolved)
@@ -122,7 +122,7 @@ Avoid:
 - [ ] Coverage for the target module is meaningful (not just line coverage — branch coverage matters)
 - [ ] No test-only code leaks into production (no `if process.env.NODE_ENV === 'test'` hacks)
 
-## Step 6 — Commit
+## Step 6 — Record test coverage additions with a scoped commit
 
 ```bash
 git add -A

--- a/.github/prompts/write-tests.prompt.md
+++ b/.github/prompts/write-tests.prompt.md
@@ -1,0 +1,134 @@
+---
+mode: agent
+description: "Write a comprehensive test suite for existing production code — covering unit, integration, and edge cases — using the conventions of the relevant stack."
+---
+
+# Write Tests
+
+You are a test-writing agent. Your job is to produce thorough, meaningful, deterministic tests for the target code. Work through the steps below in order.
+
+## Step 1 — Understand what needs testing
+
+Before writing any test, read the target module(s) and produce a coverage plan:
+
+1. List every **public function / method / class** that needs tests.
+2. For each, list the **behaviours** to verify:
+   - Happy path(s)
+   - Edge cases (empty inputs, nulls/None/undefined, boundary values, empty collections)
+   - Error / exception paths
+   - Async behaviour (if applicable)
+3. Identify **external dependencies** that must be mocked (HTTP clients, database, filesystem, time, random).
+4. Identify any gaps where **integration tests** are more appropriate than units (e.g., a DB query that is fundamentally about SQL semantics).
+
+Present this plan before writing the first test file.
+
+## Step 2 — Unit tests
+
+**Rules for all stacks**
+- Mock **all** external dependencies — no real network calls, no real DB, no real filesystem.
+- Each test must be independent and deterministic (no shared mutable state, no ordering dependency).
+- Name tests: `should <behaviour> when <condition>`.
+- One logical assertion per test where practical; prefer specific assertions over general truthiness checks.
+- If setup is complex, extract it into a fixture / factory — but keep it readable.
+
+**Python — pytest**
+```python
+# Naming
+def test_should_return_404_when_user_not_found():
+    ...
+
+# Fixtures
+@pytest.fixture
+def mock_user_repo(mocker):
+    return mocker.patch("myapp.services.user_service.UserRepository")
+
+# Parametrize for multiple input cases
+@pytest.mark.parametrize("email", ["", "not-an-email", "a@"])
+def test_should_raise_validation_error_when_email_is_invalid(email):
+    ...
+```
+
+**TypeScript — Vitest**
+```ts
+// Naming
+it('should return 404 when user not found', async () => { ... });
+
+// Mocking
+vi.mock('../repos/user-repo');
+const userRepo = vi.mocked(UserRepo);
+
+// Grouping
+describe('UserService', () => {
+  describe('getById', () => {
+    it('should return user when id exists', ...);
+    it('should throw NotFoundError when id does not exist', ...);
+  });
+});
+```
+
+**C# — xUnit + FluentAssertions**
+```csharp
+// Naming
+[Fact]
+public async Task Should_ReturnUser_When_IdExists() { ... }
+
+// Parameterised
+[Theory]
+[InlineData("")]
+[InlineData(null)]
+public async Task Should_ThrowArgumentException_When_IdIsNullOrEmpty(string? id) { ... }
+
+// Assertions
+result.Should().NotBeNull();
+result.Name.Should().Be("Alice");
+act.Should().ThrowAsync<NotFoundException>();
+```
+
+## Step 3 — Integration tests (where appropriate)
+
+Use integration tests for:
+- Database queries (SQL semantics, constraints, migrations)
+- HTTP endpoints (full request/response including middleware, serialisation)
+- Message broker interactions
+
+**Rules**
+- Use **Testcontainers** for DB / queue — never SQLite-in-memory as a stand-in for production DB.
+- Spin up a real container per test class (or module); tear it down after.
+- Only one test per test class for the same container if startup is expensive.
+
+**Stack-specific**
+- Python: `testcontainers` library; `pytest-asyncio` for async fixtures.
+- TypeScript: `testcontainers` npm package; use `supertest` for HTTP.
+- C#: `Testcontainers.PostgreSql` / `Testcontainers.MsSql`; `WebApplicationFactory<T>` for API tests.
+
+## Step 4 — Assert meaningfully
+
+Prefer:
+- Specific value assertions over `toBeTruthy()` / `Assert.True(x != null)`
+- Type-safe matchers: `FluentAssertions`, `expect(x).toEqual(...)`, `assert x == expected`
+- Verifying **side effects**: DB writes, events published, external calls made (and with what args)
+- Asserting on **error message or type**, not just that an exception was thrown
+
+Avoid:
+- Snapshots for logic tests (fragile, opaque failures)
+- `time.sleep` / `Thread.Sleep` in tests — use async patterns or test doubles for time
+
+## Step 5 — Validate
+
+- [ ] All new tests pass: `pytest -x` / `vitest run` / `dotnet test`
+- [ ] No flaky async tests (all promises awaited, all async fixtures resolved)
+- [ ] Test names are human-readable and describe the behaviour, not the implementation
+- [ ] No tests that depend on execution order
+- [ ] Coverage for the target module is meaningful (not just line coverage — branch coverage matters)
+- [ ] No test-only code leaks into production (no `if process.env.NODE_ENV === 'test'` hacks)
+
+## Step 6 — Commit
+
+```bash
+git add -A
+git commit -m "test(<scope>): add unit and integration tests for <module>
+
+Covers: <list the key behaviours tested>
+
+Closes #<issue-number>"
+```


### PR DESCRIPTION
## What
Adds three \mode: agent\ prompts to \.github/prompts/\ to standardise how agents in a task-based fleet handle the most common development tasks.

## Prompts added
| File | Purpose |
|------|---------|
| \implement-feature.prompt.md\ | Design → implement → test → self-review → commit flow |
| \write-tests.prompt.md\ | Coverage planning → unit tests → integration tests → validate |
| \ix-bug.prompt.md\ | Reproduce (failing test first) → root-cause → minimal fix → regression test → PR |

## Key decisions
- Each prompt enforces stack-specific tooling (pytest/Vitest/xUnit, Zod/Pydantic/ThrowIfNull, Testcontainers) aligned with the existing stack instruction files.
- \ix-bug\ mandates writing a failing test **before** any production code change — this prevents the common pattern of patching symptoms without tracing root cause.
- No \onboard-repo.sh\ changes needed — the script already copies \.github/prompts/\ to consumer repos.

Closes #37