### PR TITLE
fix(sync): extend pull-standards to sync MCP config, prompts, and domain instructions

### DIFF
--- a/.github/prompts/audit.prompt.md
+++ b/.github/prompts/audit.prompt.md
@@ -36,6 +36,8 @@ Every `.yml` change **must** use the absolute latest action versions. Flag anyth
 
 **Shell:** All `.sh` blocks must start with `set -euo pipefail`. All variables must be quoted.
 
+**Line length:** All `.yml` files are linted with `yamllint` at max 120 characters per line. Flag any line exceeding 120 characters — break long shell lines with `\` continuations and extract long strings into variables.
+
 ---
 
 ### 🔄 Logic & Redundancy

--- a/workflows/sync/pull-standards.yml
+++ b/workflows/sync/pull-standards.yml
@@ -108,16 +108,16 @@ jobs:
             done
           fi
 
-          # Update domain instruction files (.github/*.instructions.md, excluding code-review files
-          # already handled above and the copilot-instructions.md handled at the top)
-          DOMAIN_INSTRUCTIONS="api-design.instructions.md db-patterns.instructions.md auth-patterns.instructions.md"
-          for instr_file in $DOMAIN_INSTRUCTIONS; do
-            if [ -f "$TEMP_DIR/instructions/$instr_file" ]; then
-              mkdir -p .github
-              if ! diff -q ".github/$instr_file" "$TEMP_DIR/instructions/$instr_file" > /dev/null 2>&1; then
-                cp "$TEMP_DIR/instructions/$instr_file" ".github/$instr_file"
-                CHANGED=true
-              fi
+          # Update domain instruction files (.github/*.instructions.md),
+          # skipping code-review files already handled above
+          for instr_file in "$TEMP_DIR/instructions/"*.instructions.md; do
+            [ -f "$instr_file" ] || continue
+            fname=$(basename "$instr_file")
+            case "$fname" in code-review*.instructions.md) continue ;; esac
+            mkdir -p .github
+            if ! diff -q ".github/$fname" "$instr_file" > /dev/null 2>&1; then
+              cp "$instr_file" ".github/$fname"
+              CHANGED=true
             fi
           done
 

--- a/workflows/sync/pull-standards.yml
+++ b/workflows/sync/pull-standards.yml
@@ -50,8 +50,9 @@ jobs:
 
           # Update copilot-instructions.md if a composed file exists for this stack
           if [ -n "$STACK" ] && [ -f "$TEMP_DIR/composed/${STACK}-copilot-instructions.md" ]; then
-            if ! diff -q ".github/copilot-instructions.md" "$TEMP_DIR/composed/${STACK}-copilot-instructions.md" > /dev/null 2>&1; then
-              cp "$TEMP_DIR/composed/${STACK}-copilot-instructions.md" .github/copilot-instructions.md
+            src="$TEMP_DIR/composed/${STACK}-copilot-instructions.md"
+            if ! diff -q ".github/copilot-instructions.md" "$src" > /dev/null 2>&1; then
+              cp "$src" .github/copilot-instructions.md
               CHANGED=true
             fi
           fi
@@ -59,17 +60,21 @@ jobs:
           # Update code review instructions if present
           if [ -f "$TEMP_DIR/instructions/code-review.instructions.md" ]; then
             mkdir -p .github
-            if ! diff -q ".github/code-review.instructions.md" "$TEMP_DIR/instructions/code-review.instructions.md" > /dev/null 2>&1; then
-              cp "$TEMP_DIR/instructions/code-review.instructions.md" .github/code-review.instructions.md
+            src="$TEMP_DIR/instructions/code-review.instructions.md"
+            if ! diff -q ".github/code-review.instructions.md" "$src" > /dev/null 2>&1; then
+              cp "$src" .github/code-review.instructions.md
               CHANGED=true
             fi
           fi
 
           # Update stack-specific code review instructions if present
-          if [ -n "$STACK" ] && [ -f "$TEMP_DIR/instructions/code-review-${STACK}.instructions.md" ]; then
+          if [ -n "$STACK" ] && \
+             [ -f "$TEMP_DIR/instructions/code-review-${STACK}.instructions.md" ]; then
             mkdir -p .github
-            if ! diff -q ".github/code-review-${STACK}.instructions.md" "$TEMP_DIR/instructions/code-review-${STACK}.instructions.md" > /dev/null 2>&1; then
-              cp "$TEMP_DIR/instructions/code-review-${STACK}.instructions.md" ".github/code-review-${STACK}.instructions.md"
+            src="$TEMP_DIR/instructions/code-review-${STACK}.instructions.md"
+            dst=".github/code-review-${STACK}.instructions.md"
+            if ! diff -q "$dst" "$src" > /dev/null 2>&1; then
+              cp "$src" "$dst"
               CHANGED=true
             fi
           fi
@@ -151,11 +156,14 @@ jobs:
             });
 
             if (prs.length === 0) {
+              const repo = `https://github.com/${process.env.STANDARDS_REPO}`;
               await github.rest.pulls.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title: 'chore: update agentic standards from upstream',
-                body: `Automated PR — syncs Copilot instructions, PR templates, code-review checklists, MCP config, agent prompts, and domain instruction files from [copilot-agentic-standards](https://github.com/${process.env.STANDARDS_REPO}).`,
+                body: `Automated PR — syncs Copilot instructions, PR templates, ` +
+                  `code-review checklists, MCP config, agent prompts, and ` +
+                  `domain instruction files from [copilot-agentic-standards](${repo}).`,
                 head: process.env.UPDATE_BRANCH,
                 base: 'main',
               });

--- a/workflows/sync/pull-standards.yml
+++ b/workflows/sync/pull-standards.yml
@@ -86,6 +86,41 @@ jobs:
             done
           fi
 
+          # Update MCP config (.vscode/mcp.json) from the composed stack file
+          if [ -n "$STACK" ] && [ -f "$TEMP_DIR/composed/${STACK}.mcp.json" ]; then
+            if ! diff -q ".vscode/mcp.json" "$TEMP_DIR/composed/${STACK}.mcp.json" > /dev/null 2>&1; then
+              mkdir -p .vscode
+              cp "$TEMP_DIR/composed/${STACK}.mcp.json" .vscode/mcp.json
+              CHANGED=true
+            fi
+          fi
+
+          # Update agent prompts (.github/prompts/*.prompt.md)
+          if [ -d "$TEMP_DIR/.github/prompts" ]; then
+            mkdir -p .github/prompts
+            for prompt in "$TEMP_DIR/.github/prompts"/*.prompt.md; do
+              [ -f "$prompt" ] || continue
+              fname=$(basename "$prompt")
+              if ! diff -q ".github/prompts/$fname" "$prompt" > /dev/null 2>&1; then
+                cp "$prompt" ".github/prompts/$fname"
+                CHANGED=true
+              fi
+            done
+          fi
+
+          # Update domain instruction files (.github/*.instructions.md, excluding code-review files
+          # already handled above and the copilot-instructions.md handled at the top)
+          DOMAIN_INSTRUCTIONS="api-design.instructions.md db-patterns.instructions.md auth-patterns.instructions.md"
+          for instr_file in $DOMAIN_INSTRUCTIONS; do
+            if [ -f "$TEMP_DIR/instructions/$instr_file" ]; then
+              mkdir -p .github
+              if ! diff -q ".github/$instr_file" "$TEMP_DIR/instructions/$instr_file" > /dev/null 2>&1; then
+                cp "$TEMP_DIR/instructions/$instr_file" ".github/$instr_file"
+                CHANGED=true
+              fi
+            fi
+          done
+
           rm -rf "$TEMP_DIR"
 
           echo "changed=$CHANGED" >> "$GITHUB_ENV"
@@ -120,7 +155,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title: 'chore: update agentic standards from upstream',
-                body: `Automated PR — syncs Copilot instructions, PR templates, and review checklists from [copilot-agentic-standards](https://github.com/${process.env.STANDARDS_REPO}).`,
+                body: `Automated PR — syncs Copilot instructions, PR templates, code-review checklists, MCP config, agent prompts, and domain instruction files from [copilot-agentic-standards](https://github.com/${process.env.STANDARDS_REPO}).`,
                 head: process.env.UPDATE_BRANCH,
                 base: 'main',
               });


### PR DESCRIPTION
## What
Extends \workflows/sync/pull-standards.yml\ so the weekly sync job keeps three additional artifact categories up-to-date in consumer repos.

## Artifacts now synced
| Artifact | Source | Destination |
|----------|--------|-------------|
| MCP config | \composed/<stack>.mcp.json\ | \.vscode/mcp.json\ |
| Agent prompts | \.github/prompts/*.prompt.md\ | \.github/prompts/\ |
| Domain instructions | \instructions/{api-design,db-patterns,auth-patterns}.instructions.md\ | \.github/\ |

## Behaviour
- Each block uses the same diff-before-copy pattern as the existing sync steps — \CHANGED=true\ is only set when content actually differs, so no spurious PRs are opened.
- The automated-PR body is updated to accurately describe all synced artifacts.
- MCP sync is gated on stack detection (same guard as the \copilot-instructions.md\ sync) — if the stack comment is absent, the MCP block is skipped safely.

## Note
Domain instruction files (\pi-design\, \db-patterns\, \uth-patterns\) are introduced in PR #39 / issue #39. This PR adds the sync plumbing now so it is ready when those files land. If this PR merges before #39, the sync blocks for those files simply find nothing to copy and do nothing.

Closes #38