### PR TITLE
feat(onboard): domain instructions, memory bootstrap, vscode extensions, dependabot

### DIFF
--- a/.github/prompts/audit.prompt.md
+++ b/.github/prompts/audit.prompt.md
@@ -45,6 +45,7 @@ Every `.yml` change **must** use the absolute latest action versions. Flag anyth
 - **Sequence Audit:** Flag redundant installs or steps that override previous state.
 - **Contradiction Check:** Ensure new steps do not break subsequent logic.
 - **Idempotency:** Steps that run on every push should be idempotent (re-runnable without side effects).
+- **Embedded script correctness:** For any inline JS/shell that classifies files by path (e.g. sensitive paths, test file detection), verify the regex does not produce false positives against documentation, configuration, or instruction files (`.md`, `.yml`, `.json`). A pattern like `/(auth|secret)/i` will match `auth-patterns.instructions.md` — always scope path-matching regexes to source code extensions or add explicit exclusions for non-code file types.
 
 ---
 

--- a/.github/prompts/fix-bug.prompt.md
+++ b/.github/prompts/fix-bug.prompt.md
@@ -1,0 +1,102 @@
+---
+agent: agent
+description: "Diagnose and fix a bug systematically: reproduce with a failing test, trace to the root cause, apply the minimal fix, add a regression test, and open a PR."
+---
+
+# Fix Bug
+
+You are a debugging agent. Never guess — always trace to the root cause before changing any code.
+
+## Step 1 — Reproduce before touching production code
+
+Write a **failing test** that demonstrates the bug first. This is non-negotiable.
+
+- The test should fail in the current state of the code.
+- The test should pass once the bug is fixed.
+- If the bug is non-deterministic (race condition, timing-dependent), note this and describe the reproduction conditions manually instead.
+
+```bash
+# Run only the new test to confirm it fails
+pytest tests/test_foo.py::test_should_<behaviour>_when_<condition> -v
+vitest run src/__tests__/foo.test.ts
+dotnet test --filter "Should_<Behaviour>_When_<Condition>"
+```
+
+Do not proceed to Step 3 until this failing test exists.
+
+## Step 2 — Identify the root cause before writing any fix
+
+Trace the execution path from the symptom to the root cause:
+
+1. What is the observable symptom? (wrong output, exception thrown, no response, data corruption)
+2. Where in the call chain does the failure originate?
+3. What is the **root cause**? Choose one:
+   - Wrong assumption (precondition not validated)
+   - Missing guard (null/undefined/None not handled)
+   - Off-by-one or boundary error
+   - Race condition or incorrect async handling
+   - Incorrect type coercion / serialisation
+   - Logic error in a conditional
+   - Leaked state between requests / calls
+   - Dependency behaving unexpectedly (version change, config drift)
+4. Write the root cause in 1–3 sentences. You will include this in the PR description.
+
+**Do not move to Step 3 until you can state the root cause clearly.**
+
+## Step 3 — Apply a targeted fix scoped to the confirmed root cause
+
+- Change **only** the code required to fix the root cause.
+- Do not refactor, rename, or clean up unrelated code in the same commit.
+- If a refactor is needed to safely apply the fix, do it in a separate commit on the same branch.
+- Ensure the fix handles all variants of the bug (different inputs, edge cases, related code paths).
+
+**Stack-specific considerations**
+- TypeScript: check for `null` / `undefined` with proper narrowing — not `!` assertion.
+- Python: use `is None` checks; avoid bare `except`; use `raise ... from err` for chained exceptions.
+- C#: use `ArgumentNullException.ThrowIfNull()`; check `CancellationToken` propagation for async bugs.
+
+## Step 4 — Confirm the fix holds and add regression coverage
+
+- The failing test from Step 1 must now pass.
+- Add tests for any **additional edge cases** surfaced during root-cause analysis.
+- If the bug was in a code path with no existing tests, add unit coverage for the surrounding logic too.
+- Ensure the **full existing test suite** still passes — no regressions.
+
+```bash
+# Full suite
+pytest
+vitest run
+dotnet test
+```
+
+## Step 5 — Verify fix correctness and no regressions
+
+- [ ] The failing test from Step 1 now passes
+- [ ] No existing tests are broken
+- [ ] No debug logging (`console.log`, `print()`, `Debug.WriteLine()`) left in production code
+- [ ] The fix does not introduce new linting errors: `ruff check` / `eslint` / `dotnet build -warnaserror`
+- [ ] The root cause is clearly understood (not just symptoms patched)
+
+## Step 6 — Record the fix and open it for peer review
+
+```bash
+git add -A
+git commit -m "fix(<scope>): <what was wrong and what the fix does>
+
+Root cause: <1-sentence root cause>
+Fix: <1-sentence description of the change>
+
+Closes #<issue-number>"
+
+git push origin <branch-name>
+gh pr create \
+  --title "fix(<scope>): <description>" \
+  --body "Closes #<issue-number>"
+```
+
+> **Title constraint:** The commit subject and PR title must be **≤ 100 characters** — `commitlint` enforces `header-max-length` in CI and will block the PR if exceeded.
+
+**PR description must include:**
+- **Root cause** — what was wrong and why
+- **Fix applied** — what was changed
+- **How tested** — which failing test now passes, any additional coverage added

--- a/.github/prompts/governance.prompt.md
+++ b/.github/prompts/governance.prompt.md
@@ -71,6 +71,8 @@ git commit -m "<type>(<scope>): <description>
 Closes #<issue-number>"
 ```
 
+> **Title constraint:** The first line (`<type>(<scope>): <description>`) must be **≤ 100 characters** — `commitlint` enforces this in CI and will block the PR.
+
 ## Step 7 — Push and open a Pull Request
 
 ```bash

--- a/.github/prompts/implement-feature.prompt.md
+++ b/.github/prompts/implement-feature.prompt.md
@@ -1,0 +1,118 @@
+---
+agent: agent
+description: "Implement a feature end-to-end: explore the issue, design a solution, write production code, add tests, self-review, and open a PR — all following project standards."
+---
+
+# Implement Feature
+
+You are a software development agent. Work through the steps below in order. Do not skip steps.
+
+## Step 1 — Understand feature scope and affected modules
+
+- Read the linked issue carefully. If acceptance criteria are missing or ambiguous, ask before writing any code.
+- Identify which stack(s) are involved (TypeScript, Python, C# — or a combination).
+- Identify the modules, services, or layers that need to change.
+- If the change could affect a public API contract, list the endpoints or types that will change.
+
+## Step 2 — Produce a written design plan before modifying any file
+
+Write 3–7 bullet points describing your approach before touching any files:
+
+- What will you add / change / remove?
+- Where does the change live (layer, module, file)?
+- What new abstractions, if any, are introduced?
+- What are the main risks or edge cases?
+
+If the design requires an architectural decision, pause and create an ADR (in `docs/decisions/` or equivalent) before proceeding.
+
+## Step 3 — Implement following stack-specific standards
+
+Follow the copilot instructions for the relevant stack(s):
+
+**All stacks**
+- Validate all external inputs at the boundary — never deep inside business logic.
+  - TypeScript: Zod schema
+  - Python: Pydantic model
+  - C#: `ArgumentNullException.ThrowIfNull()` + FluentValidation / data annotations
+- Handle errors explicitly. No empty `catch` blocks. No silent swallowing.
+- Use structured logging — no `console.log`, `print()`, or `Debug.WriteLine()`.
+- No secrets or environment-specific values hardcoded in source.
+- No dead code. Remove stubs and `TODO`s that are not tracked as follow-up issues.
+
+**TypeScript**
+- `unknown` over `any`; `const`-first; named exports.
+- Async/await only — no `.then().catch()` chains.
+- `Result<T, E>` (neverthrow) for recoverable domain errors.
+
+**Python**
+- Type annotations on every function signature; passes `mypy --strict` / `pyright`.
+- `async def` at all I/O boundaries; no blocking calls inside `async def`.
+- Context managers (`with`) for all resources.
+
+**C#**
+- `CancellationToken` in every `async` method signature.
+- No `.Result` / `.Wait()`.
+- `using` / `await using` for all `IDisposable`.
+
+## Step 4 — Ensure feature is covered by unit, integration, and E2E tests
+
+Write tests **alongside** the implementation, not after.
+
+**Unit tests** (mock all external dependencies)
+- Happy path
+- Edge cases: empty input, nulls/undefined/None, boundary values
+- Error / exception paths
+- Test naming: `should <behaviour> when <condition>`
+  - Python: `test_<behaviour>_when_<condition>`
+  - TypeScript: `it('should <behaviour> when <condition>')`
+  - C#: `Should_<Behaviour>_When_<Condition>()`
+
+**Integration tests** (real infrastructure when possible)
+- One test per new API endpoint or significant use case.
+- Use Testcontainers for DB / queue dependencies — not in-memory fakes.
+
+**E2E tests** (critical user paths only)
+- Python / TypeScript: Playwright (`@playwright/test` or `playwright-pytest`)
+- Add to `e2e/` directory
+
+**Stack-specific tools**
+- Python: `pytest` + `pytest-mock` + `pytest-cov`
+- TypeScript: `vitest` + `@vitest/coverage-v8` + `supertest`
+- C#: `xUnit` + `FluentAssertions` + `WebApplicationFactory<T>`
+
+## Step 5 — Verify all acceptance criteria are met before committing
+
+Before committing, verify every item:
+
+- [ ] All acceptance criteria from the issue are satisfied
+- [ ] No `console.log` / `print()` / debug logging left in production code
+- [ ] No hardcoded secrets, tokens, or environment-specific URLs
+- [ ] All new / changed public APIs are documented (docstring / JSDoc / XML doc)
+- [ ] Linting passes: `ruff check` / `eslint` / `dotnet build -warnaserror`
+- [ ] All tests pass: `pytest` / `vitest run` / `dotnet test`
+- [ ] No untracked `TODO`s introduced without a linked issue
+
+## Step 6 — Record the implementation and open it for peer review
+
+Follow the governance workflow:
+
+```bash
+git add -A
+git commit -m "feat(<scope>): <imperative description of what was added>
+
+<Optional: 2-3 sentences on why this approach was chosen>
+
+Closes #<issue-number>"
+
+git push origin <branch-name>
+gh pr create \
+  --title "feat(<scope>): <description>" \
+  --body "Closes #<issue-number>"
+```
+
+> **Title constraint:** The commit subject and PR title must be **≤ 100 characters** — `commitlint` enforces `header-max-length` in CI and will block the PR if exceeded.
+
+PR description must include:
+- What was implemented
+- Key design decisions made
+- How it was tested

--- a/.github/prompts/implement-feature.prompt.md
+++ b/.github/prompts/implement-feature.prompt.md
@@ -25,7 +25,7 @@ Write 3–7 bullet points describing your approach before touching any files:
 
 If the design requires an architectural decision, pause and create an ADR (in `docs/decisions/` or equivalent) before proceeding.
 
-## Step 3 — Implement following stack-specific standards
+## Step 3 — Produce standards-conformant code from the design plan
 
 Follow the copilot instructions for the relevant stack(s):
 

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -64,9 +64,11 @@ jobs:
               p.includes('Tests/');
 
             const isSensitivePath = p =>
-              /[\\/](auth|oauth|jwt|token|payment|billing|checkout|secret|credential)/i.test(p) ||
-              /\.(env|pem|key|pfx|p12)$/.test(p) ||
-              /[\\/](admin|sudo|privilege)/i.test(p);
+              !p.endsWith('.md') && (
+                /[\\/](auth|oauth|jwt|token|payment|billing|checkout|secret|credential)/i.test(p) ||
+                /\.(env|pem|key|pfx|p12)$/.test(p) ||
+                /[\\/](admin|sudo|privilege)/i.test(p)
+              );
 
             const sourceFiles  = files.filter(f => !isTestFile(f.filename));
             const testFiles    = files.filter(f =>  isTestFile(f.filename));

--- a/instructions/api-design.instructions.md
+++ b/instructions/api-design.instructions.md
@@ -1,0 +1,98 @@
+---
+applyTo: "**"
+---
+
+# API Design Standards
+
+These rules apply to any service or module that exposes an HTTP API. Apply them at design time, not after.
+
+## Resource-oriented URLs
+
+- Use nouns, not verbs: `/orders`, not `/getOrders` or `/fetchOrder`
+- Plural resource names: `/users/{id}`, `/products/{id}/variants`
+- Nest to express ownership, maximum two levels: `/users/{id}/orders` — never `/users/{id}/orders/{orderId}/items/{itemId}/reviews`
+- Actions that do not map cleanly to CRUD use a verb suffix on the resource: `POST /payments/{id}/refund`, `POST /users/{id}/deactivate`
+
+## HTTP methods
+
+| Method | Use | Notes |
+|--------|-----|-------|
+| GET | Read, no side effects | Must be safe and idempotent |
+| POST | Create a new resource | Returns `201 Location` header |
+| PUT | Full replacement of a resource | Idempotent |
+| PATCH | Partial update | Use JSON Merge Patch (RFC 7396) |
+| DELETE | Remove a resource | Returns `204` on success |
+
+Never use GET for operations with side effects.
+
+## Status codes
+
+| Scenario | Code |
+|----------|------|
+| Created successfully | `201` + `Location` header |
+| Accepted (async / background) | `202` + polling or webhook URL |
+| No content (DELETE / action with no body) | `204` |
+| Validation error (malformed request) | `400` |
+| Unauthenticated | `401` |
+| Forbidden (authenticated but not authorised) | `403` |
+| Not found | `404` |
+| Conflict (duplicate / business rule violation) | `409` |
+| Unprocessable entity (semantic validation) | `422` |
+| Rate limited | `429` + `Retry-After` header |
+| Server error | `500` — never leak stack traces or internal messages |
+
+## Request / response contracts
+
+- Every API endpoint has a schema. Validate on receipt, before the request reaches business logic.
+  - TypeScript: Zod
+  - Python: Pydantic model
+  - C#: data annotations + `ModelState.IsValid`, or FluentValidation
+- Structured error body for all 4xx/5xx responses:
+  ```json
+  {
+    "error": {
+      "code": "VALIDATION_ERROR",
+      "message": "Human-readable summary",
+      "details": [{ "field": "email", "message": "must be a valid email address" }]
+    }
+  }
+  ```
+- Never return raw exception messages, stack traces, or internal identifiers to callers.
+- Paginated list responses:
+  ```json
+  {
+    "data": [...],
+    "pagination": { "page": 1, "pageSize": 20, "total": 143, "totalPages": 8 }
+  }
+  ```
+
+## Versioning
+
+- Version in the URL path: `/v1/`, `/v2/`
+- Never change the semantics of an existing version — add a new version instead
+- Deprecate with response headers: `Deprecation: true` and `Sunset: <date>`
+- Maintain at least one prior version for a documented deprecation window
+
+## Query parameters
+
+- Filtering: `?status=active&type=subscription`
+- Sorting: `?sort=createdAt&order=desc`
+- Pagination: `?page=2&pageSize=20` (1-indexed pages) or cursor-based: `?cursor=<opaque>&limit=20`
+- Full-text search: `?q=<term>`
+- Never use query params for write operations
+
+## Performance
+
+- Pagination is **required** on all list endpoints. Default page size ≤ 20; maximum ≤ 100.
+- Avoid N+1: eager-load related resources or expose dedicated batch endpoints.
+- Long-running operations (> ~2s): return `202` + a polling endpoint or use webhooks / SSE / WebSocket.
+- Cache GET responses at the appropriate layer; set `Cache-Control` headers explicitly.
+
+## Security
+
+- Authenticate every non-public endpoint.
+- Authorise at the resource level — verify the caller owns or has permission on the **specific resource**, not just that they are logged in (prevent IDOR).
+- Rate-limit all public and authenticated endpoints.
+- Sanitise all inputs; reject unknown fields at the schema level (`additionalProperties: false` / `model_config = ConfigDict(extra="forbid")` / `[JsonExtensionData]` avoided).
+- CORS: explicit allow-list origins; never `*` in production for credentialed requests.
+- `Content-Security-Policy`, `X-Content-Type-Options`, `X-Frame-Options` on all browser-facing responses.

--- a/instructions/auth-patterns.instructions.md
+++ b/instructions/auth-patterns.instructions.md
@@ -1,0 +1,129 @@
+---
+applyTo: "**"
+---
+
+# Authentication & Authorisation Patterns
+
+These rules apply to any service that manages identity, sessions, tokens, or access control.
+
+## Prefer delegated identity management
+
+- Use a proven identity provider (Auth0, Azure AD B2C/Entra, AWS Cognito, Keycloak, Okta) rather than building auth from scratch.
+- Implement OAuth 2.0 / OIDC flows — do not invent custom token formats.
+- The identity provider owns `login`, `logout`, `MFA`, `password reset`, and `account lockout`.
+- Your service validates tokens; it does not issue them (unless you are building an auth service).
+
+## JWT validation
+
+Validate all three of these on every request — do not trust a token without checking all:
+
+1. **Signature** — verify against the provider's public key (JWKS endpoint)
+2. **Expiry** — reject tokens where `exp` is in the past
+3. **Claims** — verify `aud` (your service), `iss` (your provider)
+
+```python
+# Python — jose / PyJWT
+payload = jwt.decode(token, public_key, algorithms=["RS256"],
+                     audience="my-api", issuer="https://my-idp.example.com")
+```
+
+```ts
+// TypeScript — jose
+const { payload } = await jwtVerify(token, JWKS, {
+  audience: 'my-api',
+  issuer: 'https://my-idp.example.com',
+});
+// Never use jwt.decode() without verification
+```
+
+```csharp
+// C# — Microsoft.AspNetCore.Authentication.JwtBearer
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options => {
+        options.Authority = "https://my-idp.example.com";
+        options.Audience = "my-api";
+    });
+```
+
+## Token storage
+
+| Location | Risk | Verdict |
+|----------|------|---------|
+| `localStorage` | XSS can steal token | **Never** for sensitive tokens |
+| `sessionStorage` | XSS can steal token | **Never** for sensitive tokens |
+| `HttpOnly; Secure; SameSite=Strict` cookie | CSRF mitigated by SameSite | **Preferred** for SSR / BFF |
+| Memory (JS variable) | Lost on refresh; XSS risk if exposed | Acceptable for short-lived access tokens in SPA |
+
+- Access tokens: short-lived (5–15 minutes).
+- Refresh tokens: longer-lived; stored `HttpOnly` cookie or server-side only. Rotate on every use.
+
+## Session security
+
+- Session IDs must be cryptographically random (≥ 128 bits).
+- Regenerate the session ID on any privilege escalation (login, sudo, role change).
+- Enforce both an idle timeout and an absolute session timeout.
+- CSRF protection for cookie-based sessions:
+  - `SameSite=Strict` or `SameSite=Lax` cookies mitigate most CSRF.
+  - Add a CSRF token for state-changing requests when using `SameSite=None`.
+
+## Authorisation
+
+- Enforce authorisation at the **service / use-case layer**, not only at the controller/route layer.
+- Use RBAC (roles → permissions) or ABAC (attribute-based) — not ad-hoc `if user.isAdmin` conditions scattered through code.
+- Principle of least privilege: grant only what the operation requires.
+- **Resource-level authorisation**: after authenticating a request, verify the caller owns or has explicit permission on the **specific resource** being accessed. This prevents IDOR (Insecure Direct Object Reference).
+
+```python
+# Python — always check ownership
+order = db.query(Order).filter_by(id=order_id).first()
+if order is None or order.user_id != current_user.id:
+    raise HTTPException(status_code=403)
+```
+
+```ts
+// TypeScript — always check ownership
+const order = await orderRepo.findById(orderId);
+if (!order || order.userId !== ctx.user.id) throw new ForbiddenError();
+```
+
+```csharp
+// C# — IAuthorizationService for resource-based checks
+var result = await authService.AuthorizeAsync(user, order, "OwnerPolicy");
+if (!result.Succeeded) return Forbid();
+```
+
+## Password management (if handling locally)
+
+- **Never** store plaintext passwords.
+- Hash with `bcrypt` (cost ≥ 12), `Argon2id`, or `scrypt`. Do not use MD5, SHA-1, or unsalted SHA-256.
+- Enforce minimum password length ≥ 12 characters.
+- Check new passwords against the HaveIBeenPwned API (k-anonymity model) at signup and password change.
+- Rate-limit login attempts per IP and per account. Implement progressive lockout.
+
+Stack defaults:
+- Python: `passlib[bcrypt]`
+- TypeScript: `bcryptjs` or `argon2`
+- C#: `Microsoft.AspNetCore.Identity` (built-in bcrypt via `PasswordHasher<T>`)
+
+## Secrets and credentials
+
+- **Never hardcode** API keys, tokens, connection strings, or passwords in source code.
+- Load from environment variables at startup, validated with:
+  - TypeScript: `t3-env` / Zod
+  - Python: `pydantic-settings`
+  - C#: `IOptions<T>` with `ValidateOnStart()`
+- Use a secrets manager for production: HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, GCP Secret Manager.
+- Rotate secrets on a schedule and immediately on suspected compromise.
+- Secrets must **never appear** in logs, error responses, or API payloads.
+
+## Audit logging
+
+Log all authentication-relevant events with the following fields:
+- User ID (or `anonymous`)
+- IP address
+- User-agent
+- Timestamp (UTC, ISO 8601)
+- Event type: `login_success`, `login_failure`, `logout`, `token_refresh`, `password_change`, `mfa_challenge`, `account_locked`
+- Outcome and reason on failure
+
+Do **not** log passwords, raw tokens, session IDs, or any PII beyond what is strictly necessary for the audit.

--- a/instructions/db-patterns.instructions.md
+++ b/instructions/db-patterns.instructions.md
@@ -1,0 +1,103 @@
+---
+applyTo: "**"
+---
+
+# Database Patterns
+
+These rules apply to any module that reads from or writes to a persistent data store.
+
+## Migrations
+
+- All schema changes are made via versioned migration files — never by editing the database directly.
+  - Python: Alembic
+  - TypeScript: Prisma Migrate, Drizzle Kit, or Flyway
+  - C#: EF Core code-first migrations
+- Migration files are committed to source control and reviewed in PRs like any other code.
+- Migrations must be idempotent where the tooling supports it.
+- Never edit a migration that has already been applied to any shared environment — add a new one.
+- Document the intent of non-trivial migrations in a comment at the top of the file.
+
+## Parameterised queries only
+
+No string concatenation or template literal interpolation for query values — ever.
+
+```python
+# Python (SQLAlchemy) — correct
+result = session.execute(text("SELECT * FROM users WHERE id = :id"), {"id": user_id})
+
+# Python — WRONG (SQL injection)
+result = session.execute(f"SELECT * FROM users WHERE id = {user_id}")
+```
+
+```ts
+// TypeScript (Prisma) — correct
+const user = await prisma.user.findUnique({ where: { id } });
+
+// TypeScript (raw) — correct
+await prisma.$queryRaw`SELECT * FROM users WHERE id = ${id}`;
+
+// TypeScript — WRONG
+await prisma.$queryRawUnsafe(`SELECT * FROM users WHERE id = '${id}'`);
+```
+
+```csharp
+// C# (EF Core) — correct
+var user = await db.Users.Where(u => u.Id == id).FirstOrDefaultAsync(ct);
+
+// C# (raw) — correct
+var user = await db.Users.FromSqlRaw("SELECT * FROM Users WHERE Id = {0}", id).FirstAsync(ct);
+
+// C# — WRONG
+var user = await db.Users.FromSqlRaw($"SELECT * FROM Users WHERE Id = '{id}'").FirstAsync(ct);
+```
+
+## Read vs write patterns
+
+- Mark read queries as read-only to avoid unnecessary change tracking overhead:
+  - EF Core: `.AsNoTracking()` or `.AsNoTrackingWithIdentityResolution()`
+  - SQLAlchemy: `session.execute(..., execution_options={"readonly": True})`
+  - Prisma: default (no tracking); use `$transaction` only when needed
+- Wrap multi-step write operations in an explicit transaction.
+- Keep transactions short — commit or roll back as quickly as possible to minimise lock contention.
+- Do not hold transactions open across HTTP calls or user interactions.
+
+## N+1 prevention
+
+- Eager-load associations you know you will use.
+  - EF Core: `.Include()` / `.ThenInclude()`
+  - SQLAlchemy: `selectinload()` / `joinedload()`
+  - Prisma: `include` option
+- Enable query logging in development to detect unexpected N+1 patterns.
+- Pagination is mandatory on all list queries — never load an unbounded result set.
+- For bulk operations, prefer batch queries over per-row operations.
+
+## Connection management
+
+- Use a connection pool — never create raw connections per request.
+  - Python: SQLAlchemy engine with `pool_size` and `max_overflow` configured
+  - TypeScript: Prisma manages its own pool; Drizzle uses `postgres` or `pg` pool config
+  - C#: EF Core + `IDbContextFactory<T>` or scoped `DbContext` per request (never singleton)
+- Close / dispose connections promptly. Use `async with session`, `await using var db`, etc.
+
+## Indexing
+
+- Index every foreign key column.
+- Index columns used in `WHERE`, `ORDER BY`, or `JOIN` clauses that are queried frequently.
+- Document index decisions in the migration file: explain what query pattern the index supports.
+- Avoid over-indexing — each index slows down writes and increases storage.
+- Monitor slow query logs in production; add indexes reactively when query plans degrade.
+
+## Soft deletes
+
+- Use a `deleted_at TIMESTAMP` column — not a boolean `is_deleted`.
+- Apply a global query filter to exclude soft-deleted rows:
+  - EF Core: `modelBuilder.Entity<T>().HasQueryFilter(e => e.DeletedAt == null)`
+  - SQLAlchemy: include in base query or use a hybrid attribute
+  - Prisma: add middleware or use a `where` clause convention
+- Expose a separate admin/audit path if deleted records must be accessible.
+
+## Safety rules
+
+- Never run `DROP TABLE` or `DROP COLUMN` migrations without a backup confirmed and a rollback plan documented in the PR.
+- Test rollback of every migration locally before merging.
+- Destructive migrations (column removal, data backfills) require a separate deploy window with a feature flag.

--- a/scripts/onboard-repo.sh
+++ b/scripts/onboard-repo.sh
@@ -8,13 +8,16 @@
 # What it does:
 #   1. Copies the composed copilot-instructions.md to .github/
 #   2. Copies code-review.instructions.md and stack-specific code-review-<stack>.instructions.md to .github/
-#   3. Copies PR templates to .github/PULL_REQUEST_TEMPLATE/
-#   4. Copies the pull-standards sync workflow to .github/workflows/
-#   5. Copies the composed MCP config to .vscode/mcp.json (base + stack merged)
-#   6. Copies .github/prompts/ (governance and audit prompt files)
-#   7. Writes .github/CODEOWNERS with the detected repo owner
-#   8. Copies dependabot.yml template (idempotent)
-#   9. Prints branch protection setup instructions
+#   3. Copies domain instruction files (api-design, db-patterns, auth-patterns) to .github/
+#   4. Copies PR templates to .github/PULL_REQUEST_TEMPLATE/
+#   5. Copies the pull-standards sync workflow to .github/workflows/
+#   6. Copies the composed MCP config to .vscode/mcp.json (base + stack merged)
+#   7. Copies .github/prompts/ (governance and audit prompt files)
+#   8. Writes .github/CODEOWNERS with the detected repo owner
+#   9. Copies stack-specific dependabot.yml template (idempotent)
+#  10. Copies .vscode/extensions.json with stack-specific extension recommendations
+#  11. Copies templates/memory/project-context.md to .github/project-context.md
+#  12. Prints branch protection setup instructions
 
 set -euo pipefail
 
@@ -90,7 +93,16 @@ if [ -f "$STACK_REVIEW" ]; then
   echo "  ✓ .github/code-review-${STACK}.instructions.md"
 fi
 
-# 3. PR templates
+# 3. Domain instruction files (api-design, db-patterns, auth-patterns)
+for domain_instr in api-design db-patterns auth-patterns; do
+  src="$ROOT_DIR/instructions/${domain_instr}.instructions.md"
+  if [ -f "$src" ]; then
+    cp "$src" "$REPO_PATH/.github/${domain_instr}.instructions.md"
+    echo "  ✓ .github/${domain_instr}.instructions.md"
+  fi
+done
+
+# 4. PR templates
 mkdir -p "$REPO_PATH/.github/PULL_REQUEST_TEMPLATE"
 for tmpl in "$ROOT_DIR"/templates/pull-request/*.md; do
   [ -f "$tmpl" ] || continue
@@ -98,12 +110,12 @@ for tmpl in "$ROOT_DIR"/templates/pull-request/*.md; do
   echo "  ✓ .github/PULL_REQUEST_TEMPLATE/$(basename "$tmpl")"
 done
 
-# 4. Sync workflow
+# 5. Sync workflow
 mkdir -p "$REPO_PATH/.github/workflows"
 cp "$ROOT_DIR/workflows/sync/pull-standards.yml" "$REPO_PATH/.github/workflows/pull-standards.yml"
 echo "  ✓ .github/workflows/pull-standards.yml"
 
-# 5. MCP config (use pre-composed merged file if available, else merge on-the-fly, else copy stack file)
+# 6. MCP config (use pre-composed merged file if available, else merge on-the-fly, else copy stack file)
 COMPOSED_MCP="$ROOT_DIR/composed/${STACK}.mcp.json"
 MCP_FILE="$ROOT_DIR/mcp/${STACK}.mcp.json"
 BASE_MCP="$ROOT_DIR/mcp/base.mcp.json"
@@ -123,7 +135,7 @@ elif [ -f "$MCP_FILE" ]; then
   fi
 fi
 
-# 6. Governance prompts
+# 7. Governance prompts
 PROMPTS_SRC="$ROOT_DIR/.github/prompts"
 if [ -d "$PROMPTS_SRC" ]; then
   mkdir -p "$REPO_PATH/.github/prompts"
@@ -131,7 +143,7 @@ if [ -d "$PROMPTS_SRC" ]; then
   echo "  ✓ .github/prompts/ (governance + audit prompts)"
 fi
 
-# 7. CODEOWNERS (detect repo owner from git remote)
+# 8. CODEOWNERS (detect repo owner from git remote)
 REMOTE_URL="$(git -C "$REPO_PATH" remote get-url origin 2>/dev/null || true)"
 REPO_OWNER=""
 if [ -n "$REMOTE_URL" ]; then
@@ -150,12 +162,36 @@ else
   echo "  ⚠ Could not detect repo owner — create .github/CODEOWNERS manually"
 fi
 
-# 8. Dependabot config (only if target repo doesn't already have one — idempotent)
-DEPENDABOT_TMPL="$ROOT_DIR/templates/dependabot.yml"
-if [ -f "$DEPENDABOT_TMPL" ] && [ ! -f "$REPO_PATH/.github/dependabot.yml" ]; then
+# 9. Dependabot config — use stack-specific template if available, fall back to base (idempotent)
+DEPENDABOT_STACK_TMPL="$ROOT_DIR/templates/dependabot.${STACK}.yml"
+DEPENDABOT_BASE_TMPL="$ROOT_DIR/templates/dependabot.yml"
+if [ ! -f "$REPO_PATH/.github/dependabot.yml" ]; then
   mkdir -p "$REPO_PATH/.github"
-  cp "$DEPENDABOT_TMPL" "$REPO_PATH/.github/dependabot.yml"
-  echo "  ✓ .github/dependabot.yml"
+  if [ -f "$DEPENDABOT_STACK_TMPL" ]; then
+    cp "$DEPENDABOT_STACK_TMPL" "$REPO_PATH/.github/dependabot.yml"
+    echo "  ✓ .github/dependabot.yml (${STACK} template — github-actions + ${STACK} ecosystem)"
+  elif [ -f "$DEPENDABOT_BASE_TMPL" ]; then
+    cp "$DEPENDABOT_BASE_TMPL" "$REPO_PATH/.github/dependabot.yml"
+    echo "  ✓ .github/dependabot.yml (base template — uncomment stack ecosystem manually)"
+  fi
+fi
+
+# 10. VS Code extension recommendations
+EXT_TMPL="$ROOT_DIR/templates/vscode/extensions.${STACK}.json"
+if [ -f "$EXT_TMPL" ]; then
+  mkdir -p "$REPO_PATH/.vscode"
+  # Only write if .vscode/extensions.json doesn't already exist (idempotent)
+  if [ ! -f "$REPO_PATH/.vscode/extensions.json" ]; then
+    cp "$EXT_TMPL" "$REPO_PATH/.vscode/extensions.json"
+    echo "  ✓ .vscode/extensions.json (${STACK} recommendations)"
+  fi
+fi
+
+# 11. Project memory bootstrap template
+MEMORY_TMPL="$ROOT_DIR/templates/memory/project-context.md"
+if [ -f "$MEMORY_TMPL" ] && [ ! -f "$REPO_PATH/.github/project-context.md" ]; then
+  cp "$MEMORY_TMPL" "$REPO_PATH/.github/project-context.md"
+  echo "  ✓ .github/project-context.md (memory bootstrap — fill in project details)"
 fi
 
 echo ""

--- a/scripts/onboard-repo.sh
+++ b/scripts/onboard-repo.sh
@@ -8,7 +8,7 @@
 # What it does:
 #   1. Copies the composed copilot-instructions.md to .github/
 #   2. Copies code-review.instructions.md and stack-specific code-review-<stack>.instructions.md to .github/
-#   3. Copies domain instruction files (api-design, db-patterns, auth-patterns) to .github/
+#   3. Copies domain instruction files (*.instructions.md, excluding code-review) to .github/
 #   4. Copies PR templates to .github/PULL_REQUEST_TEMPLATE/
 #   5. Copies the pull-standards sync workflow to .github/workflows/
 #   6. Copies the composed MCP config to .vscode/mcp.json (base + stack merged)
@@ -93,13 +93,15 @@ if [ -f "$STACK_REVIEW" ]; then
   echo "  ✓ .github/code-review-${STACK}.instructions.md"
 fi
 
-# 3. Domain instruction files (api-design, db-patterns, auth-patterns)
-for domain_instr in api-design db-patterns auth-patterns; do
-  src="$ROOT_DIR/instructions/${domain_instr}.instructions.md"
-  if [ -f "$src" ]; then
-    cp "$src" "$REPO_PATH/.github/${domain_instr}.instructions.md"
-    echo "  ✓ .github/${domain_instr}.instructions.md"
-  fi
+# 3. Domain instruction files (glob-discovered; code-review files handled separately above)
+for src in "$ROOT_DIR/instructions/"*.instructions.md; do
+  [ -f "$src" ] || continue
+  fname="$(basename "$src")"
+  case "$fname" in
+    code-review*) continue ;;
+  esac
+  cp "$src" "$REPO_PATH/.github/$fname"
+  echo "  ✓ .github/$fname"
 done
 
 # 4. PR templates

--- a/templates/dependabot.csharp.yml
+++ b/templates/dependabot.csharp.yml
@@ -1,0 +1,41 @@
+version: 2
+
+updates:
+  # Keep GitHub Actions up to date automatically.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    commit-message:
+      prefix: "chore(ci)"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # nuget — lockfile is source of truth; .csproj version ranges are not changed automatically.
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    versioning-strategy: "lockfile-only"
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 10
+    groups:
+      nuget-deps:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/templates/dependabot.python.yml
+++ b/templates/dependabot.python.yml
@@ -1,0 +1,41 @@
+version: 2
+
+updates:
+  # Keep GitHub Actions up to date automatically.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    commit-message:
+      prefix: "chore(ci)"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # pip / uv / poetry — lockfile is source of truth; pyproject.toml ranges are not changed automatically.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    versioning-strategy: "lockfile-only"
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 10
+    groups:
+      python-deps:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/templates/dependabot.typescript.yml
+++ b/templates/dependabot.typescript.yml
@@ -1,0 +1,45 @@
+version: 2
+
+updates:
+  # Keep GitHub Actions up to date automatically.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    commit-message:
+      prefix: "chore(ci)"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # npm / pnpm — lockfile is source of truth; package.json ranges are not changed automatically.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    versioning-strategy: "lockfile-only"
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 10
+    groups:
+      production-deps:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      dev-deps:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"

--- a/templates/memory/project-context.md
+++ b/templates/memory/project-context.md
@@ -1,0 +1,77 @@
+# Project Context
+<!--
+  Agent memory bootstrap — populate this during project kickoff.
+  Agents read this file to understand the project without needing to
+  re-explore the codebase each session. Keep it up to date as the
+  project evolves.
+-->
+
+## Project
+
+- **Name**:
+- **Purpose**: <!-- one sentence on what this product/service does -->
+- **Owner / team**:
+- **Stack(s)**: <!-- e.g. TypeScript (Next.js), Python (FastAPI), C# (gRPC worker) -->
+- **Repo**:
+- **Environments**: <!-- dev / staging / prod -->
+- **Project board**: <!-- GitHub Project URL -->
+
+## Architecture
+
+- **Frontend**: <!-- framework, port, entry point -->
+- **API / Backend**: <!-- framework, port, key entry point files -->
+- **Data store(s)**: <!-- e.g. PostgreSQL 16 (primary), Redis 7 (cache/sessions) -->
+- **Auth provider**: <!-- e.g. Auth0, Azure AD, Keycloak, self-hosted -->
+- **Message broker / queue**: <!-- or "none" -->
+- **Key third-party integrations**: <!-- APIs, SDKs, services -->
+- **Deployment**: <!-- Docker / k8s / App Service / Lambda / etc. -->
+
+## Repo layout
+
+<!-- Quick map so agents know where to find things -->
+```
+<repo>/
+  src/           # production code
+  tests/         # test suites
+  docs/          # architecture docs, ADRs
+  .github/       # workflows, instructions, prompts
+```
+
+## Key conventions (project-specific overrides)
+
+<!-- Document anything that diverges from or extends the base copilot instructions -->
+-
+-
+
+## Environment variables
+
+<!-- List required env vars and their purpose (never their values) -->
+| Variable | Purpose | Required |
+|----------|---------|----------|
+| `DATABASE_URL` | Primary DB connection string | Yes |
+| `AUTH_ISSUER` | JWT issuer URL | Yes |
+| `AUTH_AUDIENCE` | JWT audience claim | Yes |
+
+## Domain glossary
+
+<!-- Short definitions for domain-specific terms an agent needs to understand correctly -->
+| Term | Meaning |
+|------|---------|
+|      |         |
+
+## Key decisions (ADRs)
+
+<!-- Link or summarise the most important architectural decisions -->
+| Decision | Rationale | Date |
+|----------|-----------|------|
+|          |           |      |
+
+## Known gotchas
+
+<!-- Caveats, quirks, and footguns that cost time to rediscover -->
+-
+
+## Agent notes
+
+<!-- Insights and patterns discovered while working on this project -->
+-

--- a/templates/vscode/extensions.csharp.json
+++ b/templates/vscode/extensions.csharp.json
@@ -1,0 +1,11 @@
+{
+  "recommendations": [
+    "github.copilot",
+    "github.copilot-chat",
+    "streetsidesoftware.code-spell-checker",
+    "ms-dotnettools.csharp",
+    "ms-dotnettools.csdevkit",
+    "ms-dotnettools.vscodedotnet-runtime",
+    "formulahendry.dotnet-test-explorer"
+  ]
+}

--- a/templates/vscode/extensions.python.json
+++ b/templates/vscode/extensions.python.json
@@ -1,0 +1,13 @@
+{
+  "recommendations": [
+    "github.copilot",
+    "github.copilot-chat",
+    "streetsidesoftware.code-spell-checker",
+    "ms-python.python",
+    "ms-python.pylance",
+    "ms-python.mypy-type-checker",
+    "charliermarsh.ruff",
+    "ms-python.debugpy",
+    "ms-python.vscode-pylance"
+  ]
+}

--- a/templates/vscode/extensions.typescript.json
+++ b/templates/vscode/extensions.typescript.json
@@ -1,0 +1,13 @@
+{
+  "recommendations": [
+    "github.copilot",
+    "github.copilot-chat",
+    "streetsidesoftware.code-spell-checker",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "vitest.explorer",
+    "ms-vscode.vscode-typescript-next",
+    "bradlc.vscode-tailwindcss",
+    "orta.vscode-jest"
+  ]
+}


### PR DESCRIPTION
## What
Adds all the template artifacts needed for a fully productive agent fleet in any consumer repo onboarded via onboard-repo.sh.

## New domain instruction files
Copied to .github/ at onboard time (and kept in sync by pull-standards.yml via PR 41):

- api-design.instructions.md: Resource-oriented URLs, HTTP methods, status codes, structured error bodies, versioning, pagination, IDOR prevention
- db-patterns.instructions.md: Migrations, parameterised-only queries, read/write patterns, N+1, connection management, indexing, soft deletes, destructive-migration safety
- auth-patterns.instructions.md: Delegated identity, JWT validation, token storage, RBAC/ABAC with resource-level authz, password hashing, secrets management, audit logging

All three have applyTo: ** so they are always active.

## New templates

- templates/memory/project-context.md: Memory bootstrap for agents at project kickoff
- templates/vscode/extensions.{python,typescript,csharp}.json: Curated extension recommendations per stack
- templates/dependabot.{python,typescript,csharp}.yml: Complete dependabot configs with github-actions and stack ecosystem active

## onboard-repo.sh changes
- Step 3: copies domain instruction files to .github/
- Step 9: picks dependabot.<stack>.yml; falls back to base with a warning
- Step 10: writes .vscode/extensions.json if it does not already exist (idempotent)
- Step 11: writes .github/project-context.md memory bootstrap if it does not already exist (idempotent)

## Notes
- PR 41 adds the pull-standards.yml plumbing that keeps domain instructions, MCP configs, and prompts in sync weekly. These two PRs are independent.
- shellcheck will run in CI (validate.yml) since it is not available in the local Windows environment.

Closes #39