### PR TITLE
docs(audit): clarify node runtime guidance and rename pr-automation workflow

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -276,7 +276,8 @@ jobs:
               event,
             });
 
-            core.info(`Review posted: ${event} | 🚨 ${critical.length} | 💡 ${suggestions.length} | ✅ ${passing.length}`);
+            core.info(`Review posted: ${event} | 🚨 ${critical.length} | 💡 ${suggestions.length} | \
+✅ ${passing.length}`);
 
             if (hasCritical) {
               core.setFailed(`Code review found ${critical.length} critical item(s) requiring action.`);

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -276,8 +276,8 @@ jobs:
               event,
             });
 
-            core.info(`Review posted: ${event} | 🚨 ${critical.length} | 💡 ${suggestions.length} | \
-✅ ${passing.length}`);
+            const counts = `🚨 ${critical.length} | 💡 ${suggestions.length} | ✅ ${passing.length}`;
+            core.info(`Review posted: ${event} | ${counts}`);
 
             if (hasCritical) {
               core.setFailed(`Code review found ${critical.length} critical item(s) requiring action.`);

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -39,7 +39,7 @@ jobs:
             const owner = context.repo.owner;
             const repo  = context.repo.repo;
 
-            // ── 1. Gather PR metadata ────────────────────────────────────────
+            // -- 1. Gather PR metadata ----------------------------------------
             const { data: pr } = await github.rest.pulls.get({
               owner, repo, pull_number: prNumber,
             });
@@ -86,7 +86,7 @@ jobs:
             const testFiles    = files.filter(f =>  isTestFile(f.filename));
             const sensitiveFiles = sourceFiles.filter(f => isSensitivePath(f.filename));
 
-            // ── 2. Run checks ────────────────────────────────────────────────
+            // -- 2. Run checks ------------------------------------------------
 
             // 🚨 Critical checks (trigger REQUEST_CHANGES)
             const critical = [];
@@ -156,7 +156,7 @@ jobs:
               );
             }
 
-            // ── 💡 Suggestions (COMMENT only) ───────────────────────────────
+            // -- 💡 Suggestions (COMMENT only) -------------------------------
             const suggestions = [];
 
             if (prBody.trim().length < 20) {
@@ -207,7 +207,7 @@ jobs:
               );
             }
 
-            // ── ✅ Passing checks ────────────────────────────────────────────
+            // -- ✅ Passing checks --------------------------------------------
             const passing = [];
 
             if (CC_RE.test(prTitle))          passing.push('PR title follows Conventional Commits');
@@ -220,7 +220,7 @@ jobs:
                                                passing.push('Test files updated alongside source code');
             if (totalChanges <= 400)           passing.push(`PR size is reasonable (${totalChanges} lines)`);
 
-            // ── 3. Build review body ─────────────────────────────────────────
+            // -- 3. Build review body -----------------------------------------
             const hasCritical = critical.length > 0;
 
             let body = `## Automated Code Review\n\n`;
@@ -250,7 +250,7 @@ jobs:
 
             body += `\n---\n*Automated review by \`code-review.yml\`. Last run: ${new Date().toISOString()}*`;
 
-            // ── 4. Dismiss stale bot REQUEST_CHANGES reviews ─────────────────
+            // -- 4. Dismiss stale bot REQUEST_CHANGES reviews -----------------
             const { data: existingReviews } = await github.rest.pulls.listReviews({
               owner, repo, pull_number: prNumber,
             });
@@ -267,7 +267,7 @@ jobs:
               }
             }
 
-            // ── 5. Post review ───────────────────────────────────────────────
+            // -- 5. Post review -----------------------------------------------
             const event = hasCritical ? 'REQUEST_CHANGES' : 'COMMENT';
 
             await github.rest.pulls.createReview({

--- a/.github/workflows/merge-rules.yml
+++ b/.github/workflows/merge-rules.yml
@@ -50,8 +50,11 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
+          npm install --save-dev \
+            @commitlint/cli \
+            @commitlint/config-conventional
           echo '{"extends":["@commitlint/config-conventional"]}' > .commitlintrc.json
-          echo "$PR_TITLE" | npx --yes commitlint --verbose
+          echo "$PR_TITLE" | npx commitlint --verbose
 
   squash-check:
     name: Enforce squash-merge is enabled in repository settings

--- a/.github/workflows/merge-rules.yml
+++ b/.github/workflows/merge-rules.yml
@@ -125,8 +125,8 @@ jobs:
 
             // Expected: type/ISSUE_NUMBER-short-slug
             // e.g. feat/42-add-oauth-flow  fix/123-null-crash
-            const VALID = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|hotfix|bugfix)\/\
-\d+-[a-z0-9][a-z0-9-]*$/;
+            const TYPES = 'feat|fix|docs|style|refactor|perf|test|build|ci|chore|hotfix|bugfix';
+            const VALID = new RegExp('^(' + TYPES + ')/\\d+-[a-z0-9][a-z0-9-]*$');
 
             if (!VALID.test(branch)) {
               core.setFailed(

--- a/.github/workflows/merge-rules.yml
+++ b/.github/workflows/merge-rules.yml
@@ -125,7 +125,8 @@ jobs:
 
             // Expected: type/ISSUE_NUMBER-short-slug
             // e.g. feat/42-add-oauth-flow  fix/123-null-crash
-            const VALID = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|hotfix|bugfix)\/\d+-[a-z0-9][a-z0-9-]*$/;
+            const VALID = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|hotfix|bugfix)\/\
+\d+-[a-z0-9][a-z0-9-]*$/;
 
             if (!VALID.test(branch)) {
               core.setFailed(

--- a/.github/workflows/merge-rules.yml
+++ b/.github/workflows/merge-rules.yml
@@ -14,7 +14,7 @@
 # Authentication: uses GITHUB_TOKEN automatically. No secrets need to be passed.
 # The caller must declare: permissions: contents: read, pull-requests: read
 
-name: Merge Rules
+name: Enforce conventional commits, squash-merge, and branch naming policy
 
 on:
   pull_request:
@@ -41,37 +41,24 @@ permissions:
 
 jobs:
   commitlint:
-    name: Validate PR title (Conventional Commits)
+    name: Enforce Conventional Commits format on PR title
     # Always runs on pull_request; on workflow_call, runs unless explicitly disabled
     if: ${{ github.event_name != 'workflow_call' || inputs.commitlint-enabled }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js (LTS)
-        uses: actions/setup-node@v6
-        with:
-          node-version: lts/*
-
-      - name: Install commitlint
-        run: |
-          npm install --save-dev @commitlint/{cli,config-conventional}
-          echo "module.exports = { extends: ['@commitlint/config-conventional'] };" > commitlint.config.js
-
-      - name: Validate PR title
+      - name: Enforce PR title follows Conventional Commits format
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-        run: echo "$PR_TITLE" | npx commitlint --verbose
+        run: |
+          echo '{"extends":["@commitlint/config-conventional"]}' > .commitlintrc.json
+          echo "$PR_TITLE" | npx --yes commitlint --verbose
 
   squash-check:
-    name: Verify squash merge is enabled
+    name: Enforce squash-merge is enabled in repository settings
     if: ${{ github.event_name != 'workflow_call' || inputs.require-linear-history }}
     runs-on: ubuntu-latest
     steps:
-      - name: Check repository merge settings
+      - name: Enforce squash-only merge method
         uses: actions/github-script@v9
         with:
           script: |
@@ -106,11 +93,11 @@ jobs:
             }
 
   branch-name:
-    name: Validate branch name
+    name: Enforce issue-linked branch naming convention
     if: ${{ github.event_name != 'workflow_call' || inputs.branch-check-enabled }}
     runs-on: ubuntu-latest
     steps:
-      - name: Check branch naming convention
+      - name: Enforce branch name matches type/issue-slug pattern
         uses: actions/github-script@v9
         with:
           script: |

--- a/.github/workflows/merge-rules.yml
+++ b/.github/workflows/merge-rules.yml
@@ -50,11 +50,12 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          npm install --save-dev \
-            @commitlint/cli \
-            @commitlint/config-conventional
           echo '{"extends":["@commitlint/config-conventional"]}' > .commitlintrc.json
-          echo "$PR_TITLE" | npx commitlint --verbose
+          echo "$PR_TITLE" | npx \
+            --yes \
+            --package=@commitlint/cli@20.5.0 \
+            --package=@commitlint/config-conventional@20.5.0 \
+            commitlint --verbose
 
   squash-check:
     name: Enforce squash-merge is enabled in repository settings

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -45,7 +45,7 @@ permissions:
 
 jobs:
   auto-assign:
-    name: Assign PR to author
+    name: Enforce PR auto-assigned to its author
     if: ${{ github.event_name != 'workflow_call' || inputs.auto-assign-author }}
     runs-on: ubuntu-latest
     steps:
@@ -74,7 +74,7 @@ jobs:
             });
 
   label:
-    name: Apply path-based labels
+    name: Enforce path-based label classification
     # Only runs when explicitly enabled; requires .github/labeler.yml in the caller's repo
     if: ${{ inputs.enable-labeler == true }}
     runs-on: ubuntu-latest
@@ -82,10 +82,10 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Checkout
+      - name: Checkout repository for label config access
         uses: actions/checkout@v6
 
-      - name: Label PR
+      - name: Apply path-based labels from labeler.yml
         uses: actions/labeler@v6
         with:
           configuration-path: .github/labeler.yml

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -92,7 +92,7 @@ jobs:
           sync-labels: true
 
   welcome-comment:
-    name: Welcome first-time contributor
+    name: Enforce first-contribution welcome comment
     runs-on: ubuntu-latest
     steps:
       - name: Post welcome comment on first PR

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -1,4 +1,4 @@
-# PR Automation
+# Auto-assign PRs, apply labels, and welcome contributors
 #
 # Dual-trigger:
 #   1. pull_request — runs automatically on PRs in this repo
@@ -19,7 +19,7 @@
 # the auto-created "update standards" PRs to trigger CI, use a fine-grained PAT
 # or GitHub App token in pull-standards.yml instead.
 
-name: PR Automation
+name: Auto-assign PRs, apply labels, and welcome contributors
 
 on:
   pull_request:

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -74,7 +74,11 @@ jobs:
           github-token: ${{ secrets.PR_TOKEN || github.token }}
           script: |
             if ('${{ secrets.PR_TOKEN }}' === '') {
-              core.setFailed('PR_TOKEN secret is not configured. Add a classic PAT with the project scope as a repository secret named PR_TOKEN. See workflow header comment for setup instructions.');
+              core.setFailed(
+                'PR_TOKEN secret is not configured. Add a classic PAT with the project ' +
+                'scope as a repository secret named PR_TOKEN. ' +
+                'See workflow header comment for setup instructions.'
+              );
               return;
             }
 
@@ -153,7 +157,11 @@ jobs:
           github-token: ${{ secrets.PR_TOKEN || github.token }}
           script: |
             if ('${{ secrets.PR_TOKEN }}' === '') {
-              core.setFailed('PR_TOKEN secret is not configured. Add a classic PAT with the project scope as a repository secret named PR_TOKEN. See workflow header comment for setup instructions.');
+              core.setFailed(
+                'PR_TOKEN secret is not configured. Add a classic PAT with the project ' +
+                'scope as a repository secret named PR_TOKEN. ' +
+                'See workflow header comment for setup instructions.'
+              );
               return;
             }
 
@@ -249,7 +257,11 @@ jobs:
           github-token: ${{ secrets.PR_TOKEN || github.token }}
           script: |
             if ('${{ secrets.PR_TOKEN }}' === '') {
-              core.setFailed('PR_TOKEN secret is not configured. Add a classic PAT with the project scope as a repository secret named PR_TOKEN. See workflow header comment for setup instructions.');
+              core.setFailed(
+                'PR_TOKEN secret is not configured. Add a classic PAT with the project ' +
+                'scope as a repository secret named PR_TOKEN. ' +
+                'See workflow header comment for setup instructions.'
+              );
               return;
             }
 
@@ -376,7 +388,11 @@ jobs:
           github-token: ${{ secrets.PR_TOKEN || github.token }}
           script: |
             if ('${{ secrets.PR_TOKEN }}' === '') {
-              core.setFailed('PR_TOKEN secret is not configured. Add a classic PAT with the project scope as a repository secret named PR_TOKEN. See workflow header comment for setup instructions.');
+              core.setFailed(
+                'PR_TOKEN secret is not configured. Add a classic PAT with the project ' +
+                'scope as a repository secret named PR_TOKEN. ' +
+                'See workflow header comment for setup instructions.'
+              );
               return;
             }
 

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -366,7 +366,7 @@ jobs:
        github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     permissions:
-      contents: write      # required for enablePullRequestAutoMerge
+      contents: write # required for enablePullRequestAutoMerge
       pull-requests: write # required for enablePullRequestAutoMerge
       issues: read
     steps:

--- a/scripts/onboard-repo.sh
+++ b/scripts/onboard-repo.sh
@@ -420,13 +420,17 @@ if [ -n "$_REPO_OWNER_LOGIN" ]; then
   # as literals without triggering SC2016 (which fires on $ inside single-quoted strings).
   _GQL_GET_OWNER_ID="query(\$login:String!){user(login:\$login){id}}"
   _GQL_LIST_PROJECTS="query(\$login:String!){user(login:\$login){projectsV2(first:20){nodes{id,title}}}}"
-  _GQL_CREATE_PROJECT="mutation(\$ownerId:ID!,\$title:String!){createProjectV2(input:{ownerId:\$ownerId," \
-"title:\$title}){projectV2{id}}}"
-  _GQL_GET_STATUS_FIELD="query(\$id:ID!){node(id:\$id){...on ProjectV2{field(name:\"Status\")" \
-"{...on ProjectV2SingleSelectField{id}}}}}"
-  _GQL_SET_STATUS_OPTIONS="mutation(\$fid:ID!){updateProjectV2Field(input:{fieldId:\$fid," \
-"singleSelectOptions:[{name:\"Todo\",color:GRAY,description:\"\"},{name:\"In Progress\",color:BLUE,description:\"\"}," \
-"{name:\"In Review\",color:YELLOW,description:\"PR open, awaiting review\"},{name:\"Done\",color:GREEN,description:\"\"}]}){projectV2Field{...on ProjectV2SingleSelectField{options{name}}}}}"
+  _GQL_CREATE_PROJECT="mutation(\$ownerId:ID!,\$title:String!)"
+  _GQL_CREATE_PROJECT+="{createProjectV2(input:{ownerId:\$ownerId,title:\$title}){projectV2{id}}}"
+  _GQL_GET_STATUS_FIELD="query(\$id:ID!){node(id:\$id){...on ProjectV2"
+  _GQL_GET_STATUS_FIELD+="{field(name:\"Status\"){...on ProjectV2SingleSelectField{id}}}}}"
+  _GQL_SET_STATUS_OPTIONS="mutation(\$fid:ID!){updateProjectV2Field(input:{fieldId:\$fid,"
+  _GQL_SET_STATUS_OPTIONS+="singleSelectOptions:["
+  _GQL_SET_STATUS_OPTIONS+="{name:\"Todo\",color:GRAY,description:\"\"},"
+  _GQL_SET_STATUS_OPTIONS+="{name:\"In Progress\",color:BLUE,description:\"\"},"
+  _GQL_SET_STATUS_OPTIONS+="{name:\"In Review\",color:YELLOW,description:\"PR open, awaiting review\"},"
+  _GQL_SET_STATUS_OPTIONS+="{name:\"Done\",color:GREEN,description:\"\"}]"
+  _GQL_SET_STATUS_OPTIONS+="}){projectV2Field{...on ProjectV2SingleSelectField{options{name}}}}}"
 
   _OWNER_NODE_ID="$(_gh_project api graphql \
     -f query="$_GQL_GET_OWNER_ID" \

--- a/scripts/onboard-repo.sh
+++ b/scripts/onboard-repo.sh
@@ -46,7 +46,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 usage() {
-  echo "Usage: $0 --repo <path> --stack <stack> [--create] [--force] [--visibility public|private] [--project-name <name>]"
+  echo "Usage: $0 --repo <path> --stack <stack> [--create] [--force] \
+[--visibility public|private] [--project-name <name>]"
   echo ""
   echo "Options:"
   echo "  --repo          Path to the target repository (must exist, unless --create is used)"
@@ -379,22 +380,32 @@ _REPO_FULL=""
 _REPO_OWNER_LOGIN=""
 _REPO_NAME_SLUG=""
 if command -v gh > /dev/null 2>&1; then
-  _REPO_FULL="$(git -C "$REPO_PATH" remote get-url origin 2>/dev/null | sed -E 's|.*[:/]([^/]+/[^/]+)(\.git)?$|\1|')" || true
+  _REPO_FULL="$(git -C "$REPO_PATH" remote get-url origin 2>/dev/null | \
+sed -E 's|.*[:/]([^/]+/[^/]+)(\.git)?$|\1|')" || true
   _REPO_OWNER_LOGIN="$(echo "$_REPO_FULL" | cut -d'/' -f1)"
   _REPO_NAME_SLUG="$(echo "$_REPO_FULL" | cut -d'/' -f2)"
 fi
 
 # 17. Conventional commit labels (idempotent — --force updates if already exists)
 if [ -n "$_REPO_FULL" ]; then
-  gh label create "feat"     --repo "$_REPO_FULL" --description "New feature"                            --color "0075ca" --force 2>/dev/null
-  gh label create "fix"      --repo "$_REPO_FULL" --description "Bug fix"                                --color "d73a4a" --force 2>/dev/null
-  gh label create "chore"    --repo "$_REPO_FULL" --description "Maintenance, tooling, config"           --color "e4e669" --force 2>/dev/null
-  gh label create "docs"     --repo "$_REPO_FULL" --description "Documentation changes"                  --color "0075ca" --force 2>/dev/null
-  gh label create "refactor" --repo "$_REPO_FULL" --description "Code restructuring, no behavior change" --color "c5def5" --force 2>/dev/null
-  gh label create "perf"     --repo "$_REPO_FULL" --description "Performance improvement"                --color "0e8a16" --force 2>/dev/null
-  gh label create "test"     --repo "$_REPO_FULL" --description "Tests only"                             --color "f9c74f" --force 2>/dev/null
-  gh label create "ci"       --repo "$_REPO_FULL" --description "CI/CD pipeline changes"                 --color "000000" --force 2>/dev/null
-  gh label create "style"    --repo "$_REPO_FULL" --description "Formatting, whitespace"                 --color "ffffff" --force 2>/dev/null
+  gh label create "feat"     --repo "$_REPO_FULL" --description "New feature" \
+    --color "0075ca" --force 2>/dev/null
+  gh label create "fix"      --repo "$_REPO_FULL" --description "Bug fix" \
+    --color "d73a4a" --force 2>/dev/null
+  gh label create "chore"    --repo "$_REPO_FULL" --description "Maintenance, tooling, config" \
+    --color "e4e669" --force 2>/dev/null
+  gh label create "docs"     --repo "$_REPO_FULL" --description "Documentation changes" \
+    --color "0075ca" --force 2>/dev/null
+  gh label create "refactor" --repo "$_REPO_FULL" --description "Code restructuring, no behavior change" \
+    --color "c5def5" --force 2>/dev/null
+  gh label create "perf"     --repo "$_REPO_FULL" --description "Performance improvement" \
+    --color "0e8a16" --force 2>/dev/null
+  gh label create "test"     --repo "$_REPO_FULL" --description "Tests only" \
+    --color "f9c74f" --force 2>/dev/null
+  gh label create "ci"       --repo "$_REPO_FULL" --description "CI/CD pipeline changes" \
+    --color "000000" --force 2>/dev/null
+  gh label create "style"    --repo "$_REPO_FULL" --description "Formatting, whitespace" \
+    --color "ffffff" --force 2>/dev/null
   echo "  ✓ Conventional commit labels (feat, fix, chore, docs, refactor, perf, test, ci, style)"
 fi
 
@@ -409,9 +420,13 @@ if [ -n "$_REPO_OWNER_LOGIN" ]; then
   # as literals without triggering SC2016 (which fires on $ inside single-quoted strings).
   _GQL_GET_OWNER_ID="query(\$login:String!){user(login:\$login){id}}"
   _GQL_LIST_PROJECTS="query(\$login:String!){user(login:\$login){projectsV2(first:20){nodes{id,title}}}}"
-  _GQL_CREATE_PROJECT="mutation(\$ownerId:ID!,\$title:String!){createProjectV2(input:{ownerId:\$ownerId,title:\$title}){projectV2{id}}}"
-  _GQL_GET_STATUS_FIELD="query(\$id:ID!){node(id:\$id){...on ProjectV2{field(name:\"Status\"){...on ProjectV2SingleSelectField{id}}}}}"
-  _GQL_SET_STATUS_OPTIONS="mutation(\$fid:ID!){updateProjectV2Field(input:{fieldId:\$fid,singleSelectOptions:[{name:\"Todo\",color:GRAY,description:\"\"},{name:\"In Progress\",color:BLUE,description:\"\"},{name:\"In Review\",color:YELLOW,description:\"PR open, awaiting review\"},{name:\"Done\",color:GREEN,description:\"\"}]}){projectV2Field{...on ProjectV2SingleSelectField{options{name}}}}}"
+  _GQL_CREATE_PROJECT="mutation(\$ownerId:ID!,\$title:String!){createProjectV2(input:{ownerId:\$ownerId," \
+"title:\$title}){projectV2{id}}}"
+  _GQL_GET_STATUS_FIELD="query(\$id:ID!){node(id:\$id){...on ProjectV2{field(name:\"Status\")" \
+"{...on ProjectV2SingleSelectField{id}}}}}"
+  _GQL_SET_STATUS_OPTIONS="mutation(\$fid:ID!){updateProjectV2Field(input:{fieldId:\$fid," \
+"singleSelectOptions:[{name:\"Todo\",color:GRAY,description:\"\"},{name:\"In Progress\",color:BLUE,description:\"\"}," \
+"{name:\"In Review\",color:YELLOW,description:\"PR open, awaiting review\"},{name:\"Done\",color:GREEN,description:\"\"}]}){projectV2Field{...on ProjectV2SingleSelectField{options{name}}}}}"
 
   _OWNER_NODE_ID="$(_gh_project api graphql \
     -f query="$_GQL_GET_OWNER_ID" \
@@ -462,8 +477,10 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 echo ""
 echo "Run the following commands from inside the target repo (requires admin access):"
 echo ""
-printf '%s\n' "  REPO_FULL=\"\$(git -C \"$REPO_PATH\" remote get-url origin | sed -E 's|.*[:/]([^/]+/[^/]+)(.git)?\$|\\1|')\""
-echo "  DEFAULT_BRANCH=\"\$(git -C \"$REPO_PATH\" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|.*/||' || echo main)\""
+printf '%s\n' "  REPO_FULL=\"\$(git -C \"$REPO_PATH\" remote get-url origin | \
+sed -E 's|.*[:/]([^/]+/[^/]+)(.git)?\$|\\1|')\""
+echo "  DEFAULT_BRANCH=\"\$(git -C \"$REPO_PATH\" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | \
+sed 's|.*/||' || echo main)\""
 echo ""
 echo "  gh api repos/\${REPO_FULL}/branches/\${DEFAULT_BRANCH}/protection \\"
 echo "    --method PUT \\"

--- a/workflows/reusable/pr-automation.yml
+++ b/workflows/reusable/pr-automation.yml
@@ -73,7 +73,7 @@ jobs:
           sync-labels: true
 
   welcome-comment:
-    name: Welcome first-time contributor
+    name: Enforce first-contribution welcome comment
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/workflows/reusable/pr-automation.yml
+++ b/workflows/reusable/pr-automation.yml
@@ -34,7 +34,7 @@ on:
 
 jobs:
   auto-assign:
-    name: Assign PR to author
+    name: Enforce PR auto-assigned to its author
     if: ${{ inputs.auto-assign-author }}
     runs-on: ubuntu-latest
     permissions:
@@ -56,17 +56,17 @@ jobs:
             });
 
   label:
-    name: Apply path-based labels
+    name: Enforce path-based label classification
     if: ${{ inputs.enable-labeler }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
     steps:
-      - name: Checkout
+      - name: Checkout repository for label config access
         uses: actions/checkout@v6
 
-      - name: Label PR
+      - name: Apply path-based labels from labeler.yml
         uses: actions/labeler@v6
         with:
           configuration-path: .github/labeler.yml

--- a/workflows/reusable/pr-automation.yml
+++ b/workflows/reusable/pr-automation.yml
@@ -18,7 +18,7 @@
 #
 # Authentication: uses GITHUB_TOKEN automatically. No secrets need to be passed.
 
-name: PR Automation
+name: Auto-assign PRs, apply labels, and welcome contributors
 
 on:
   workflow_call:


### PR DESCRIPTION
## Summary

Post-merge audit fixes for #53.

## Changes

- \udit.prompt.md\: Node runtime guidance now explicitly warns that \
ode-version\ is not a valid input for \ctions/github-script\ — silently ignored. Only a major version bump upgrades the bundled runtime.
- \pr-automation.yml\: Renamed from \PR Automation\ (tool name) to \Auto-assign PRs, apply labels, and welcome contributors\ (policy statement). Fixes file-path display in GitHub Actions sidebar.
- \project-automation.yml\: Formatter alignment fix.

Closes #54
