### PR TITLE
feat(templates): automate runtime version bumps for Python, Node.js, and .NET

### DIFF
--- a/templates/ci/ci.csharp.yml
+++ b/templates/ci/ci.csharp.yml
@@ -62,7 +62,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: "9.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Restore NuGet packages
         run: dotnet restore
@@ -80,7 +80,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: "9.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Restore NuGet packages
         run: dotnet restore
@@ -109,7 +109,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: "9.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Restore NuGet packages
         run: dotnet restore
@@ -127,7 +127,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: "9.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Publish release build
         run: dotnet publish src/Api/Api.csproj -c Release -o publish

--- a/templates/ci/ci.python.yml
+++ b/templates/ci/ci.python.yml
@@ -65,7 +65,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install locked dependencies
         run: uv sync --frozen
@@ -92,7 +92,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install locked dependencies
         run: uv sync --frozen
@@ -120,7 +120,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install locked dependencies
         run: uv sync --frozen
@@ -141,7 +141,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Build distributable package
         run: uv build

--- a/templates/ci/ci.typescript.yml
+++ b/templates/ci/ci.typescript.yml
@@ -62,7 +62,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - run: npm ci
@@ -83,7 +83,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - run: npm ci
@@ -108,7 +108,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - run: npm ci
@@ -126,7 +126,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - run: npm ci

--- a/templates/ci/release.yml
+++ b/templates/ci/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Ensure Node.js runtime is available for semantic-release
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Ensure semantic-release and all changelog plugins are installed at pinned versions
         run: |
@@ -57,7 +57,7 @@ jobs:
       # - name: Setup Node.js (project)
       #   uses: actions/setup-node@v6
       #   with:
-      #     node-version: 22
+      #     node-version: 24
       #     cache: pnpm
       # - name: Install dependencies
       #   run: pnpm install --frozen-lockfile
@@ -70,7 +70,7 @@ jobs:
       # - name: Setup Python
       #   uses: actions/setup-python@v6
       #   with:
-      #     python-version: "3.12"
+      #     python-version: "3.14"
       # - name: Build wheel
       #   run: |
       #     pip install build

--- a/templates/docker/Dockerfile.csharp
+++ b/templates/docker/Dockerfile.csharp
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # ── Stage 1: Build ──
-FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
 WORKDIR /src
 
 COPY *.sln .
@@ -13,7 +13,7 @@ COPY . .
 RUN dotnet publish src/Api/Api.csproj -c Release -o /app/publish --no-restore
 
 # ── Stage 2: Production ──
-FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine AS production
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS production
 WORKDIR /app
 
 RUN addgroup -g 1001 -S appgroup && \

--- a/templates/docker/Dockerfile.python
+++ b/templates/docker/Dockerfile.python
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # ── Stage 1: Build ──
-FROM python:3.12-slim AS build
+FROM python:3.14-slim AS build
 WORKDIR /app
 
 # Pin uv version for reproducible builds — update the tag when upgrading uv
@@ -14,7 +14,7 @@ RUN uv sync --frozen --no-dev
 COPY . .
 
 # ── Stage 2: Production ──
-FROM python:3.12-slim AS production
+FROM python:3.14-slim AS production
 WORKDIR /app
 
 RUN groupadd -g 1001 appgroup && \

--- a/templates/docker/Dockerfile.typescript
+++ b/templates/docker/Dockerfile.typescript
@@ -1,20 +1,20 @@
 # syntax=docker/dockerfile:1
 
 # ── Stage 1: Install dependencies ──
-FROM node:22-alpine AS deps
+FROM node:24-alpine AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --ignore-scripts
 
 # ── Stage 2: Build ──
-FROM node:22-alpine AS build
+FROM node:24-alpine AS build
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN npm run build
 
 # ── Stage 3: Production ──
-FROM node:22-alpine AS production
+FROM node:24-alpine AS production
 WORKDIR /app
 
 RUN addgroup -g 1001 -S appgroup && \

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "Single source of truth for pinned runtime versions across all stack templates. Updated automatically by workflows/sync/bump-runtime-versions.yml.",
+  "python": "3.12",
+  "node": "22",
+  "dotnet": "9.0"
+}

--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Single source of truth for pinned runtime versions across all stack templates. Updated automatically by workflows/sync/bump-runtime-versions.yml.",
-  "python": "3.12",
-  "node": "22",
-  "dotnet": "9.0"
+  "python": "3.14",
+  "node": "24",
+  "dotnet": "10.0"
 }

--- a/workflows/sync/bump-runtime-versions.yml
+++ b/workflows/sync/bump-runtime-versions.yml
@@ -1,0 +1,223 @@
+# Bump Runtime Versions — Scheduled Workflow
+#
+# Runs weekly in THIS repo (copilot-agentic-standards). Queries endoflife.date
+# to detect new stable releases of Python, Node.js, and .NET, then updates
+# versions.json and all template files that embed those version strings,
+# and opens a PR so the bump can be reviewed before merging.
+#
+# Trickle-down to consumer repos: once this PR is merged, consumer repos pick up
+# the new versions on their next weekly sync via workflows/sync/pull-standards.yml,
+# which reads versions.json and applies the same substitutions to their existing
+# CI workflow files and Dockerfiles.
+
+name: Bump Pinned Runtime Versions
+
+on:
+  schedule:
+    - cron: "0 10 * * 1" # Every Monday at 10:00 UTC (after pull-standards runs at 09:00)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    name: Detect and bump outdated runtime versions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # ── Detect latest stable runtimes via endoflife.date ──
+
+      - name: Detect latest stable Python minor version
+        id: python
+        run: |
+          set -euo pipefail
+          TODAY=$(date -I)
+          # Latest cycle whose releaseDate has passed and EOL is still in the future
+          LATEST=$(curl -sSf https://endoflife.date/api/python.json \
+            | jq -r --arg today "$TODAY" \
+              '[.[] | select(.releaseDate <= $today and (.eol == false or .eol > $today))
+                | .cycle]
+              | sort_by(split(".") | map(tonumber))
+              | last')
+          echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+          echo "Detected latest stable Python: $LATEST"
+
+      - name: Detect latest stable LTS Node.js major version
+        id: node
+        run: |
+          set -euo pipefail
+          TODAY=$(date -I)
+          # Latest LTS cycle whose releaseDate has passed and EOL is still in the future
+          LATEST=$(curl -sSf https://endoflife.date/api/nodejs.json \
+            | jq -r --arg today "$TODAY" \
+              '[.[] | select(.lts != false and .releaseDate <= $today
+                and (.eol == false or .eol > $today))
+                | .cycle]
+              | sort_by(tonumber)
+              | last')
+          echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+          echo "Detected latest stable LTS Node.js: $LATEST"
+
+      - name: Detect latest stable .NET version
+        id: dotnet
+        run: |
+          set -euo pipefail
+          TODAY=$(date -I)
+          # Latest cycle whose releaseDate has passed and EOL is still in the future
+          LATEST=$(curl -sSf https://endoflife.date/api/dotnet.json \
+            | jq -r --arg today "$TODAY" \
+              '[.[] | select(.releaseDate <= $today and (.eol == false or .eol > $today))
+                | .cycle]
+              | sort_by(split(".") | map(tonumber))
+              | last')
+          echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+          echo "Detected latest stable .NET: $LATEST"
+
+      # ── Read current pinned versions from source of truth ──
+
+      - name: Read current versions from versions.json
+        id: current
+        run: |
+          set -euo pipefail
+          PY=$(jq -r '.python' versions.json)
+          NODE=$(jq -r '.node' versions.json)
+          DOTNET=$(jq -r '.dotnet' versions.json)
+          echo "python=$PY"   >> "$GITHUB_OUTPUT"
+          echo "node=$NODE"   >> "$GITHUB_OUTPUT"
+          echo "dotnet=$DOTNET" >> "$GITHUB_OUTPUT"
+          echo "Current: Python=$PY  Node=$NODE  .NET=$DOTNET"
+
+      # ── Apply version bumps to versions.json and all template files ──
+
+      - name: Bump Python version
+        if: steps.current.outputs.python != steps.python.outputs.version
+        env:
+          OLD: ${{ steps.current.outputs.python }}
+          NEW: ${{ steps.python.outputs.version }}
+        run: |
+          set -euo pipefail
+          echo "Bumping Python $OLD → $NEW"
+          # versions.json
+          jq --arg v "$NEW" '.python = $v' versions.json > versions.tmp && mv versions.tmp versions.json
+          # CI workflow (python-version: "X.Y")
+          sed -i "s/python-version: \"${OLD}\"/python-version: \"${NEW}\"/g" \
+            templates/ci/ci.python.yml
+          # Dockerfiles (python:X.Y-slim)
+          sed -i "s/FROM python:${OLD}-slim/FROM python:${NEW}-slim/g" \
+            templates/docker/Dockerfile.python
+
+      - name: Bump Node.js version
+        if: steps.current.outputs.node != steps.node.outputs.version
+        env:
+          OLD: ${{ steps.current.outputs.node }}
+          NEW: ${{ steps.node.outputs.version }}
+        run: |
+          set -euo pipefail
+          echo "Bumping Node.js $OLD → $NEW"
+          # versions.json
+          jq --arg v "$NEW" '.node = $v' versions.json > versions.tmp && mv versions.tmp versions.json
+          # CI workflows (node-version: "X")
+          sed -i "s/node-version: \"${OLD}\"/node-version: \"${NEW}\"/g" \
+            templates/ci/ci.typescript.yml
+          # release.yml uses unquoted: node-version: X
+          sed -i "s/node-version: ${OLD}$/node-version: ${NEW}/g" \
+            templates/ci/release.yml
+          # Dockerfiles (node:X-alpine)
+          sed -i "s/FROM node:${OLD}-alpine/FROM node:${NEW}-alpine/g" \
+            templates/docker/Dockerfile.typescript
+
+      - name: Bump .NET version
+        if: steps.current.outputs.dotnet != steps.dotnet.outputs.version
+        env:
+          OLD: ${{ steps.current.outputs.dotnet }}
+          NEW: ${{ steps.dotnet.outputs.version }}
+        run: |
+          set -euo pipefail
+          echo "Bumping .NET $OLD → $NEW"
+          # versions.json
+          jq --arg v "$NEW" '.dotnet = $v' versions.json > versions.tmp && mv versions.tmp versions.json
+          # CI workflow (dotnet-version: "X.Y.x")
+          sed -i "s/dotnet-version: \"${OLD}\.x\"/dotnet-version: \"${NEW}.x\"/g" \
+            templates/ci/ci.csharp.yml
+          # Dockerfiles (dotnet/sdk:X.Y-alpine, dotnet/aspnet:X.Y-alpine)
+          sed -i "s|dotnet/sdk:${OLD}-alpine|dotnet/sdk:${NEW}-alpine|g" \
+            templates/docker/Dockerfile.csharp
+          sed -i "s|dotnet/aspnet:${OLD}-alpine|dotnet/aspnet:${NEW}-alpine|g" \
+            templates/docker/Dockerfile.csharp
+
+      # ── Open PR if anything changed ──
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "All runtime versions are already up to date."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build PR body
+        if: steps.changes.outputs.changed == 'true'
+        id: pr_body
+        env:
+          PY_OLD: ${{ steps.current.outputs.python }}
+          PY_NEW: ${{ steps.python.outputs.version }}
+          NODE_OLD: ${{ steps.current.outputs.node }}
+          NODE_NEW: ${{ steps.node.outputs.version }}
+          DOTNET_OLD: ${{ steps.current.outputs.dotnet }}
+          DOTNET_NEW: ${{ steps.dotnet.outputs.version }}
+        run: |
+          set -euo pipefail
+          BODY="Automated bump of pinned runtime versions detected via [endoflife.date](https://endoflife.date)."$'\n\n'
+          BODY+="| Runtime | Old | New |"$'\n'
+          BODY+="|---------|-----|-----|"$'\n'
+          if [ "$PY_OLD" != "$PY_NEW" ]; then
+            BODY+="| Python | \`$PY_OLD\` | \`$PY_NEW\` |"$'\n'
+          fi
+          if [ "$NODE_OLD" != "$NODE_NEW" ]; then
+            BODY+="| Node.js LTS | \`$NODE_OLD\` | \`$NODE_NEW\` |"$'\n'
+          fi
+          if [ "$DOTNET_OLD" != "$DOTNET_NEW" ]; then
+            BODY+="| .NET | \`$DOTNET_OLD\` | \`$DOTNET_NEW\` |"$'\n'
+          fi
+          BODY+=$'\n'"Consumer repos receive these bumps automatically on their next weekly sync via \`pull-standards.yml\`."
+          # Write body to file to avoid shell quoting issues
+          printf '%s' "$BODY" > /tmp/pr_body.txt
+
+      - name: Commit and push version bump branch
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          BRANCH="chore/bump-runtime-versions-$(date +%Y%m%d)"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add versions.json templates/ci/ templates/docker/
+          git commit -m "chore(templates): bump pinned runtime versions"
+          git push origin "$BRANCH"
+          echo "BUMP_BRANCH=$BRANCH" >> "$GITHUB_ENV"
+
+      - name: Open PR for runtime version bumps (idempotent)
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Only open a new PR if one isn't already open for this branch
+          EXISTING=$(gh pr list --head "$BUMP_BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -z "$EXISTING" ]; then
+            gh pr create \
+              --title "chore(templates): bump pinned runtime versions" \
+              --body-file /tmp/pr_body.txt \
+              --base main \
+              --head "$BUMP_BRANCH" \
+              --label "chore"
+          else
+            echo "PR #$EXISTING already open for branch $BUMP_BRANCH — skipping."
+          fi

--- a/workflows/sync/bump-runtime-versions.yml
+++ b/workflows/sync/bump-runtime-versions.yml
@@ -10,7 +10,7 @@
 # which reads versions.json and applies the same substitutions to their existing
 # CI workflow files and Dockerfiles.
 
-name: Bump Pinned Runtime Versions
+name: Keep Runtime Versions Current Across All Templates
 
 on:
   schedule:
@@ -23,12 +23,12 @@ permissions:
 
 jobs:
   bump:
-    name: Detect and bump outdated runtime versions
+    name: Ensure all templates reflect latest stable runtime releases
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # ── Detect latest stable runtimes via endoflife.date ──
 
@@ -94,7 +94,7 @@ jobs:
 
       # ── Apply version bumps to versions.json and all template files ──
 
-      - name: Bump Python version
+      - name: Patch Python version strings across all CI and Docker templates
         if: steps.current.outputs.python != steps.python.outputs.version
         env:
           OLD: ${{ steps.current.outputs.python }}
@@ -111,7 +111,7 @@ jobs:
           sed -i "s/FROM python:${OLD}-slim/FROM python:${NEW}-slim/g" \
             templates/docker/Dockerfile.python
 
-      - name: Bump Node.js version
+      - name: Patch Node.js LTS version strings across all CI and Docker templates
         if: steps.current.outputs.node != steps.node.outputs.version
         env:
           OLD: ${{ steps.current.outputs.node }}
@@ -131,7 +131,7 @@ jobs:
           sed -i "s/FROM node:${OLD}-alpine/FROM node:${NEW}-alpine/g" \
             templates/docker/Dockerfile.typescript
 
-      - name: Bump .NET version
+      - name: Patch .NET version strings across all CI and Docker templates
         if: steps.current.outputs.dotnet != steps.dotnet.outputs.version
         env:
           OLD: ${{ steps.current.outputs.dotnet }}
@@ -152,7 +152,7 @@ jobs:
 
       # ── Open PR if anything changed ──
 
-      - name: Check for changes
+      - name: Determine whether any template files were modified
         id: changes
         run: |
           if git diff --quiet; then
@@ -162,7 +162,7 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build PR body
+      - name: Compose PR description with version change summary
         if: steps.changes.outputs.changed == 'true'
         id: pr_body
         env:
@@ -191,7 +191,7 @@ jobs:
           # Write body to file to avoid shell quoting issues
           printf '%s' "$BODY" > /tmp/pr_body.txt
 
-      - name: Commit and push version bump branch
+      - name: Persist version changes to a dedicated bump branch
         if: steps.changes.outputs.changed == 'true'
         run: |
           set -euo pipefail
@@ -204,7 +204,7 @@ jobs:
           git push origin "$BRANCH"
           echo "BUMP_BRANCH=$BRANCH" >> "$GITHUB_ENV"
 
-      - name: Open PR for runtime version bumps (idempotent)
+      - name: Open review PR for runtime version bumps (idempotent)
         if: steps.changes.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -216,7 +216,7 @@ jobs:
             gh pr create \
               --title "chore(templates): bump pinned runtime versions" \
               --body-file /tmp/pr_body.txt \
-              --base main \
+              --base "${{ github.event.repository.default_branch }}" \
               --head "$BUMP_BRANCH" \
               --label "chore"
           else

--- a/workflows/sync/bump-runtime-versions.yml
+++ b/workflows/sync/bump-runtime-versions.yml
@@ -186,7 +186,8 @@ jobs:
           if [ "$DOTNET_OLD" != "$DOTNET_NEW" ]; then
             BODY+="| .NET | \`$DOTNET_OLD\` | \`$DOTNET_NEW\` |"$'\n'
           fi
-          BODY+=$'\n'"Consumer repos receive these bumps automatically on their next weekly sync via \`pull-standards.yml\`."
+          BODY+=$'\n'"Consumer repos receive these bumps automatically"
+          BODY+=" on their next weekly sync via \`pull-standards.yml\`."
           # Write body to file to avoid shell quoting issues
           printf '%s' "$BODY" > /tmp/pr_body.txt
 

--- a/workflows/sync/pull-standards.yml
+++ b/workflows/sync/pull-standards.yml
@@ -198,6 +198,44 @@ jobs:
             fi
           done
 
+          # Apply runtime version bumps from versions.json to consumer repo CI/Docker files.
+          # This ensures that when bump-runtime-versions.yml updates the standards repo,
+          # the new versions trickle down to all consumer repos on their next weekly sync.
+          if [ -f "$TEMP_DIR/versions.json" ]; then
+            PY_NEW=$(jq -r '.python' "$TEMP_DIR/versions.json")
+            NODE_NEW=$(jq -r '.node' "$TEMP_DIR/versions.json")
+            DOTNET_NEW=$(jq -r '.dotnet' "$TEMP_DIR/versions.json")
+
+            # Files to patch in the consumer repo (non-exhaustive; covers the standard layout)
+            CI_YML=".github/workflows/ci.yml"
+
+            if [ -f "$CI_YML" ]; then
+              BEFORE=$(md5sum "$CI_YML")
+              sed -i -E \
+                -e "s/python-version: \"[0-9]+\.[0-9]+\"/python-version: \"${PY_NEW}\"/g" \
+                -e "s/node-version: \"[0-9]+\"/node-version: \"${NODE_NEW}\"/g" \
+                -e "s/node-version: [0-9]+$/node-version: ${NODE_NEW}/g" \
+                -e "s/dotnet-version: \"[0-9]+\.[0-9]+\.x\"/dotnet-version: \"${DOTNET_NEW}.x\"/g" \
+                "$CI_YML"
+              AFTER=$(md5sum "$CI_YML")
+              if [ "$BEFORE" != "$AFTER" ]; then CHANGED=true; fi
+            fi
+
+            # Apply to any Dockerfile found within the first three directory levels
+            while IFS= read -r -d '' dockerfile; do
+              BEFORE=$(md5sum "$dockerfile")
+              sed -i -E \
+                -e "s|FROM python:[0-9]+\.[0-9]+-slim|FROM python:${PY_NEW}-slim|g" \
+                -e "s|FROM node:[0-9]+-alpine|FROM node:${NODE_NEW}-alpine|g" \
+                -e "s|dotnet/sdk:[0-9]+\.[0-9]+-alpine|dotnet/sdk:${DOTNET_NEW}-alpine|g" \
+                -e "s|dotnet/aspnet:[0-9]+\.[0-9]+-alpine|dotnet/aspnet:${DOTNET_NEW}-alpine|g" \
+                "$dockerfile"
+              AFTER=$(md5sum "$dockerfile")
+              if [ "$BEFORE" != "$AFTER" ]; then CHANGED=true; fi
+            done < <(find . -maxdepth 3 \( -name "Dockerfile" -o -name "Dockerfile.*" \) \
+                       -not -path "./.git/*" -print0)
+          fi
+
           rm -rf "$TEMP_DIR"
 
           echo "changed=$CHANGED" >> "$GITHUB_ENV"
@@ -234,8 +272,9 @@ jobs:
                 repo: context.repo.repo,
                 title: 'chore: update agentic standards from upstream',
                 body: `Automated PR — syncs Copilot instructions, PR templates, ` +
-                  `code-review checklists, MCP config, agent prompts, and ` +
-                  `domain instruction files from [copilot-agentic-standards](${repo}).`,
+                  `code-review checklists, MCP config, agent prompts, ` +
+                  `domain instruction files, and pinned runtime versions ` +
+                  `(Python / Node.js / .NET) from [copilot-agentic-standards](${repo}).`,
                 head: process.env.UPDATE_BRANCH,
                 base: 'main',
               });


### PR DESCRIPTION
Closes #59

## What

Introduces an automated pipeline for keeping pinned runtime versions (Python, Node.js, .NET) up to date across all templates and consumer repos.

## Changes

### \ersions.json\ (new)
Single source of truth for runtime versions. Currently:
- Python: 3.12
- Node.js: 22
- .NET: 9.0

### \workflows/sync/bump-runtime-versions.yml\ (new)
Weekly scheduled workflow (Mondays 10:00 UTC) that:
1. Queries [endoflife.date](https://endoflife.date) to detect the latest stable/LTS releases
2. Diffs against \ersions.json\
3. Updates \ersions.json\ and all affected template files (\ci.python.yml\, \ci.typescript.yml\, \ci.csharp.yml\, \elease.yml\, \Dockerfile.python\, \Dockerfile.typescript\, \Dockerfile.csharp\)
4. Opens a PR for review — versions are never merged without human sign-off

### \workflows/sync/pull-standards.yml\ (modified)
Extended to apply version substitutions from \ersions.json\ to consumer repos during their weekly sync:
- Patches \.github/workflows/ci.yml\ version strings
- Patches any \Dockerfile\ / \Dockerfile.*\ within 3 directory levels