### PR TITLE
fix(ci): pin GitHub Actions to commit SHAs and add SECURITY.md

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Auto-correct title and post agent-ready action checklist
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Evaluate PR diff and post structured tiered review
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/merge-rules.yml
+++ b/.github/workflows/merge-rules.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Enforce squash-only merge method
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const { data: repo } = await github.rest.repos.get({
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Enforce branch name matches type/issue-slug pattern
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const branch = context.payload.pull_request?.head?.ref ?? '';

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto-assign PR to its author
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -83,10 +83,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository for label config access
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Apply path-based labels from labeler.yml
-        uses: actions/labeler@v6
+        uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b  # v6.0.1
         with:
           configuration-path: .github/labeler.yml
           sync-labels: true
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post welcome comment on first PR
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Write PR body from branch Conventional Commits
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             // HTML comment used to identify auto-generated descriptions.

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add issue to project board as Todo
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           github-token: ${{ secrets.PR_TOKEN || github.token }}
           script: |
@@ -150,7 +150,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Move issue to In Progress
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           # Fall back to GITHUB_TOKEN so the action never crashes when the secret is absent.
           # The script itself exits early if PR_TOKEN is not configured.
@@ -252,7 +252,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Request review and move to In Review
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           github-token: ${{ secrets.PR_TOKEN || github.token }}
           script: |
@@ -383,7 +383,7 @@ jobs:
       issues: read
     steps:
       - name: Move linked issues to Done
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           github-token: ${{ secrets.PR_TOKEN || github.token }}
           script: |
@@ -492,7 +492,7 @@ jobs:
       # status checks pass. Skipped on the pull_request:closed safety-net trigger.
       - name: Enable squash auto-merge
         if: github.event_name == 'pull_request_review'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,10 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository for shellcheck analysis
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Run shellcheck
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # 2.0.0
         with:
           scandir: "./scripts"
 
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository with full history for freshness comparison
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Make scripts executable
         run: chmod +x scripts/compose.sh scripts/validate-composed.sh
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository to access MCP config files
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Validate all MCP JSON files parse correctly
         run: |
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository to access workflow and config files
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up yamllint for YAML syntax validation
         run: pip install --quiet "yamllint==1.35.1"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,62 @@
+# Security Policy
+
+## Supported versions
+
+This repository distributes CI/CD templates, instructions, and workflow files — not a versioned software package. Security fixes are applied to `main` and propagated to consumers via the standard sync workflow.
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities by [creating a private security advisory](https://github.com/h-urena/copilot-agentic-standards/security/advisories/new) in this repository. Include:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a proof-of-concept
+- The affected file(s) and line numbers, if applicable
+
+You will receive an acknowledgement within **5 business days** and a resolution or mitigation plan within **30 days**.
+
+## Scope
+
+| Area | In scope |
+|------|----------|
+| GitHub Actions workflow files (`.github/workflows/`) | ✅ |
+| Distributed CI templates (`templates/`) | ✅ |
+| Reusable workflows (`workflows/`) | ✅ |
+| Copilot instruction files (`instructions/`, `composed/`) | ✅ |
+| Scripts (`scripts/`) — shell injection, path traversal | ✅ |
+
+## Supply chain policy
+
+### Action pinning
+
+All GitHub Actions `uses:` references **must** be pinned to a full 40-character commit SHA with the human-readable version in a trailing comment:
+
+```yaml
+# Correct
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+# Incorrect — mutable tag, do not use
+- uses: actions/checkout@v6
+```
+
+Pinning is validated by the dependency audit prompt (`.github/prompts/review/dependency-audit.prompt.md`).
+
+### Adding a new action
+
+Before adding a new third-party action:
+
+1. Review the action's source code and recent commit history.
+2. Confirm the action comes from a well-known publisher or has significant community adoption.
+3. Pin to the **specific commit SHA** of the version you reviewed.
+4. Document the version and date of review in the PR description.
+
+### CVE exception log
+
+If a vulnerability cannot be fixed immediately, it must be tracked here with a mitigation:
+
+| CVE | Package | Severity | Reason unfixed | Mitigation | Target fix date |
+|-----|---------|----------|----------------|------------|----------------|
+| — | — | — | — | — | — |
+
+When an exception is resolved, remove the row and close the associated tracking issue.

--- a/templates/ci/ci.csharp.yml
+++ b/templates/ci/ci.csharp.yml
@@ -58,9 +58,9 @@ jobs:
     name: Application compiles with zero warnings
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5.2.0
         with:
           dotnet-version: "9.0.x"
 
@@ -76,9 +76,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5.2.0
         with:
           dotnet-version: "9.0.x"
 
@@ -94,7 +94,7 @@ jobs:
 
       - name: Persist coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-unit
           path: coverage/
@@ -105,9 +105,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5.2.0
         with:
           dotnet-version: "9.0.x"
 
@@ -123,9 +123,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test-unit, test-integration]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5.2.0
         with:
           dotnet-version: "9.0.x"
 
@@ -133,7 +133,7 @@ jobs:
         run: dotnet publish src/Api/Api.csproj -c Release -o publish
 
       - name: Persist publish artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: publish
           path: publish/
@@ -144,7 +144,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   needs: publish
   #   steps:
-  #     - uses: actions/checkout@v6
+  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
   #
   #     - name: Build Docker image
   #       run: docker build -t app:${{ github.sha }} .

--- a/templates/ci/ci.python.yml
+++ b/templates/ci/ci.python.yml
@@ -58,12 +58,12 @@ jobs:
     name: Enforce code style and type safety
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up uv package manager
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
 
@@ -85,12 +85,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up uv package manager
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
 
@@ -102,7 +102,7 @@ jobs:
 
       - name: Persist coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-unit
           path: coverage.xml
@@ -113,12 +113,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up uv package manager
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
 
@@ -134,12 +134,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test-unit, test-integration]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up uv package manager
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
 
@@ -147,7 +147,7 @@ jobs:
         run: uv build
 
       - name: Persist build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: dist
           path: dist/
@@ -158,7 +158,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   needs: build
   #   steps:
-  #     - uses: actions/checkout@v6
+  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
   #
   #     - name: Build Docker image
   #       run: docker build -t app:${{ github.sha }} .

--- a/templates/ci/ci.typescript.yml
+++ b/templates/ci/ci.typescript.yml
@@ -58,9 +58,9 @@ jobs:
     name: Enforce code style and type safety
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "22"
           cache: "npm"
@@ -79,9 +79,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "22"
           cache: "npm"
@@ -93,7 +93,7 @@ jobs:
 
       - name: Persist coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-unit
           path: coverage/
@@ -104,9 +104,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "22"
           cache: "npm"
@@ -122,9 +122,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test-unit, test-integration]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "22"
           cache: "npm"
@@ -135,7 +135,7 @@ jobs:
         run: npm run build
 
       - name: Persist build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: dist
           path: dist/
@@ -146,7 +146,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   needs: build
   #   steps:
-  #     - uses: actions/checkout@v6
+  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
   #
   #     - name: Build Docker image
   #       run: docker build -t app:${{ github.sha }} .

--- a/templates/ci/release.yml
+++ b/templates/ci/release.yml
@@ -29,13 +29,13 @@ jobs:
 
     steps:
       - name: Ensure full git history is available for commit analysis
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0     # semantic-release needs full history
           persist-credentials: false
 
       - name: Ensure Node.js runtime is available for semantic-release
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 22
 
@@ -55,7 +55,7 @@ jobs:
       # Uncomment and adjust if this is a TypeScript project.
       #
       # - name: Setup Node.js (project)
-      #   uses: actions/setup-node@v6
+      #   uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
       #   with:
       #     node-version: 22
       #     cache: pnpm
@@ -68,7 +68,7 @@ jobs:
       # Uncomment and adjust if this is a Python project.
       #
       # - name: Setup Python
-      #   uses: actions/setup-python@v6
+      #   uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       #   with:
       #     python-version: "3.12"
       # - name: Build wheel
@@ -80,7 +80,7 @@ jobs:
       # Uncomment and adjust if this is a C# project.
       #
       # - name: Setup .NET
-      #   uses: actions/setup-dotnet@v5
+      #   uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5.2.0
       #   with:
       #     dotnet-version: "9.x"
       # - name: Build and pack

--- a/templates/ci/stale.yml
+++ b/templates/ci/stale.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Apply stale labels and close issues and PRs that exceed inactivity thresholds
-        uses: actions/stale@v9
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639  # v9.1.0
         with:
           # ── Issues ────────────────────────────────────────────────────
           days-before-issue-stale: 30

--- a/workflows/examples/example-ci.yml
+++ b/workflows/examples/example-ci.yml
@@ -36,6 +36,6 @@ jobs:
   # build:
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v6
+  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
   #     - run: npm ci
   #     - run: npm test

--- a/workflows/reusable/merge-rules.yml
+++ b/workflows/reusable/merge-rules.yml
@@ -41,12 +41,12 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Node.js (LTS)
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: lts/*
 
@@ -68,7 +68,7 @@ jobs:
       contents: read
     steps:
       - name: Check repository merge settings
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const { data: repo } = await github.rest.repos.get({

--- a/workflows/reusable/pr-automation.yml
+++ b/workflows/reusable/pr-automation.yml
@@ -42,7 +42,7 @@ jobs:
       issues: write
     steps:
       - name: Auto-assign PR to its author
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -64,10 +64,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository for label config access
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Apply path-based labels from labeler.yml
-        uses: actions/labeler@v6
+        uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b  # v6.0.1
         with:
           configuration-path: .github/labeler.yml
           sync-labels: true
@@ -80,7 +80,7 @@ jobs:
       issues: write
     steps:
       - name: Post welcome comment on first PR
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/workflows/reusable/pr-description.yml
+++ b/workflows/reusable/pr-description.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Write PR body from branch Conventional Commits
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             # See .github/workflows/pr-description.yml for the full implementation.

--- a/workflows/sync/pull-standards.yml
+++ b/workflows/sync/pull-standards.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout consumer repo at full depth for git operations
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
@@ -217,7 +217,7 @@ jobs:
 
       - name: Open PR to deliver standards updates (idempotent)
         if: env.changed == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const { data: prs } = await github.rest.pulls.list({


### PR DESCRIPTION
Resolves two open findings from the dependency audit.

Changes:
1. Pin all GitHub Actions to commit SHAs across 17 files (checkout v6.0.2, github-script v9.0.0, labeler v6.0.1, setup-node v6.4.0, setup-python v6.2.0, setup-dotnet v5.2.0, upload-artifact v7.0.1, stale v9.1.0, setup-uv v4.2.0, action-shellcheck 2.0.0).
2. Add SECURITY.md with vulnerability reporting process, scope, action pinning policy, and CVE exception log table.

Closes #61