### PR TITLE
fix(ci): pin reusable workflow refs to commit SHAs

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,6 +1,6 @@
 extends: relaxed
 rules:
   line-length:
-    max: 120
+    max: 160  # 40-char SHA-pinned `uses:` lines can reach ~130 chars; 160 gives safe headroom
     level: error
   new-lines: disable  # Windows uses CRLF; git handles conversion

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,6 +1,6 @@
 extends: relaxed
 rules:
   line-length:
-    max: 140  # 40-char SHA-pinned `uses:` lines can reach ~130 chars; 140 gives safe headroom
+    max: 130  # SHA-pinned `uses:` lines peak at 130 chars (pr-description.yml); no extra headroom needed
     level: error
   new-lines: disable  # Windows uses CRLF; git handles conversion

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,6 +1,6 @@
 extends: relaxed
 rules:
   line-length:
-    max: 160  # 40-char SHA-pinned `uses:` lines can reach ~130 chars; 160 gives safe headroom
+    max: 140  # 40-char SHA-pinned `uses:` lines can reach ~130 chars; 140 gives safe headroom
     level: error
   new-lines: disable  # Windows uses CRLF; git handles conversion

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,6 +42,20 @@ All GitHub Actions `uses:` references **must** be pinned to a full 40-character 
 
 Pinning is validated by the dependency audit prompt (`.github/prompts/review/dependency-audit.prompt.md`).
 
+### Reusable workflow pinning
+
+All `uses:` references to reusable workflows (including those sourced from this repository) **must** also be pinned to a full 40-character commit SHA with a branch or tag comment. Using a mutable ref such as `@main` means that any future commit — including a malicious one from a compromised account — would automatically run against all consumer repositories:
+
+```yaml
+# Correct — pinned to a specific commit SHA
+uses: h-urena/copilot-agentic-standards/.github/workflows/pr-automation.yml@86c5acf98f7f2aa66b66f5f728de4f290c3160b0  # main
+
+# Incorrect — mutable ref, supply-chain risk
+uses: h-urena/copilot-agentic-standards/.github/workflows/pr-automation.yml@main
+```
+
+When the standards repo is updated (e.g., via the `pull-standards` sync workflow), consumer repos **must** update the pinned SHA at the same time. Treat SHA bumps with the same care as dependency upgrades: review the diff between the old and new SHA before merging.
+
 ### Adding a new action
 
 Before adding a new third-party action:

--- a/templates/ci/ci.csharp.yml
+++ b/templates/ci/ci.csharp.yml
@@ -25,20 +25,20 @@ jobs:
   # ── Governance checks (reusable from standards repo) ──
   merge-rules:
     if: github.event_name == 'pull_request'
-    uses: h-urena/copilot-agentic-standards/.github/workflows/merge-rules.yml@main
+    uses: h-urena/copilot-agentic-standards/.github/workflows/merge-rules.yml@86c5acf98f7f2aa66b66f5f728de4f290c3160b0  # main
     permissions:
       contents: read
       pull-requests: read
 
   pr-description:
     if: github.event_name == 'pull_request'
-    uses: h-urena/copilot-agentic-standards/.github/workflows/pr-description.yml@main
+    uses: h-urena/copilot-agentic-standards/.github/workflows/pr-description.yml@86c5acf98f7f2aa66b66f5f728de4f290c3160b0  # main
     permissions:
       pull-requests: write
 
   pr-automation:
     if: github.event_name == 'pull_request'
-    uses: h-urena/copilot-agentic-standards/.github/workflows/pr-automation.yml@main
+    uses: h-urena/copilot-agentic-standards/.github/workflows/pr-automation.yml@86c5acf98f7f2aa66b66f5f728de4f290c3160b0  # main
     permissions:
       contents: read
       pull-requests: write
@@ -48,7 +48,7 @@ jobs:
 
   code-review:
     if: github.event_name == 'pull_request'
-    uses: h-urena/copilot-agentic-standards/.github/workflows/code-review.yml@main
+    uses: h-urena/copilot-agentic-standards/.github/workflows/code-review.yml@86c5acf98f7f2aa66b66f5f728de4f290c3160b0  # main
     permissions:
       contents: read
       pull-requests: write

--- a/templates/ci/ci.python.yml
+++ b/templates/ci/ci.python.yml
@@ -25,20 +25,20 @@ jobs:
   # ── Governance checks (reusable from standards repo) ──
   merge-rules:
     if: github.event_name == 'pull_request'
-    uses: h-urena/copilot-agentic-standards/.github/workflows/merge-rules.yml@main
+    uses: h-urena/copilot-agentic-standards/.github/workflows/merge-rules.yml@86c5acf98f7f2aa66b66f5f728de4f290c3160b0  # main
     permissions:
       contents: read
       pull-requests: read
 
   pr-description:
     if: github.event_name == 'pull_request'
-    uses: h-urena/copilot-agentic-standards/.github/workflows/pr-description.yml@main
+    uses: h-urena/copilot-agentic-standards/.github/workflows/pr-description.yml@86c5acf98f7f2aa66b66f5f728de4f290c3160b0  # main
     permissions:
       pull-requests: write
 
   pr-automation:
     if: github.event_name == 'pull_request'
-    uses: h-urena/copilot-agentic-standards/.github/workflows/pr-automation.yml@main
+    uses: h-urena/copilot-agentic-standards/.github/workflows/pr-automation.yml@86c5acf98f7f2aa66b66f5f728de4f290c3160b0  # main
     permissions:
       contents: read
       pull-requests: write
@@ -48,7 +48,7 @@ jobs:
 
   code-review:
     if: github.event_name == 'pull_request'
-    uses: h-urena/copilot-agentic-standards/.github/workflows/code-review.yml@main
+    uses: h-urena/copilot-agentic-standards/.github/workflows/code-review.yml@86c5acf98f7f2aa66b66f5f728de4f290c3160b0  # main
     permissions:
       contents: read
       pull-requests: write

--- a/templates/ci/ci.typescript.yml
+++ b/templates/ci/ci.typescript.yml
@@ -25,20 +25,20 @@ jobs:
   # ── Governance checks (reusable from standards repo) ──
   merge-rules:
     if: github.event_name == 'pull_request'
-    uses: h-urena/copilot-agentic-standards/.github/workflows/merge-rules.yml@main
+    uses: h-urena/copilot-agentic-standards/.github/workflows/merge-rules.yml@86c5acf98f7f2aa66b66f5f728de4f290c3160b0  # main
     permissions:
       contents: read
       pull-requests: read
 
   pr-description:
     if: github.event_name == 'pull_request'
-    uses: h-urena/copilot-agentic-standards/.github/workflows/pr-description.yml@main
+    uses: h-urena/copilot-agentic-standards/.github/workflows/pr-description.yml@86c5acf98f7f2aa66b66f5f728de4f290c3160b0  # main
     permissions:
       pull-requests: write
 
   pr-automation:
     if: github.event_name == 'pull_request'
-    uses: h-urena/copilot-agentic-standards/.github/workflows/pr-automation.yml@main
+    uses: h-urena/copilot-agentic-standards/.github/workflows/pr-automation.yml@86c5acf98f7f2aa66b66f5f728de4f290c3160b0  # main
     permissions:
       contents: read
       pull-requests: write
@@ -48,7 +48,7 @@ jobs:
 
   code-review:
     if: github.event_name == 'pull_request'
-    uses: h-urena/copilot-agentic-standards/.github/workflows/code-review.yml@main
+    uses: h-urena/copilot-agentic-standards/.github/workflows/code-review.yml@86c5acf98f7f2aa66b66f5f728de4f290c3160b0  # main
     permissions:
       contents: read
       pull-requests: write

--- a/workflows/examples/example-ci.yml
+++ b/workflows/examples/example-ci.yml
@@ -20,14 +20,14 @@ permissions:
 jobs:
   merge-rules:
     name: Merge Rules
-    uses: h-urena/copilot-agentic-standards/.github/workflows/merge-rules.yml@main
+    uses: h-urena/copilot-agentic-standards/.github/workflows/merge-rules.yml@86c5acf98f7f2aa66b66f5f728de4f290c3160b0  # main
     with:
       require-linear-history: true
       commitlint-enabled: true
 
   pr-automation:
     name: PR Automation
-    uses: h-urena/copilot-agentic-standards/.github/workflows/pr-automation.yml@main
+    uses: h-urena/copilot-agentic-standards/.github/workflows/pr-automation.yml@86c5acf98f7f2aa66b66f5f728de4f290c3160b0  # main
     with:
       auto-assign-author: true
       enable-labeler: false # set to true once you add .github/labeler.yml


### PR DESCRIPTION
Pins all @main reusable workflow references in CI templates and example-ci.yml to commit SHA 86c5acf98f7f2aa66b66f5f728de4f290c3160b0 to prevent supply-chain attacks. Also raises yamllint line-length max to 140 to accommodate SHA-pinned uses lines. Updates SECURITY.md supply-chain policy. Closes #65