### PR TITLE
chore(docker): add *.pem, *.key, *.p12 to .dockerignore

### DIFF
--- a/templates/docker/.dockerignore
+++ b/templates/docker/.dockerignore
@@ -16,6 +16,9 @@ coverage
 *.env
 *.env.*
 !*.env.example
+*.pem
+*.key
+*.p12
 .DS_Store
 Thumbs.db
 docker-compose*.yml


### PR DESCRIPTION
## Summary

Adds missing sensitive file patterns to `templates/docker/.dockerignore` to prevent private keys and certificates from being copied into container images.

**Added patterns:**
- `*.pem` — PEM-encoded certificates and private keys
- `*.key` — private key files
- `*.p12` — PKCS#12 keystore files

The `.env` / `.env.*` exclusion was already present. The `docker-compose.yml` comment directing users to populate `.env` from `.env.example` was also already in place.

**OWASP A02:2021 – Cryptographic Failures**: secrets and key material must never be baked into container images.

Closes #66