### PR TITLE
docs(standards): update docs for green/brown field workflows and fix determinism gaps

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,42 +9,108 @@ You are working on the **copilot-agentic-standards** repo — the single source 
 - Files in `composed/` are **auto-generated** by `scripts/compose.sh`. Never edit them directly.
 - Workflows in `.github/workflows/` use dual triggers (`pull_request` for this repo + `workflow_call` for consumers). Files in `workflows/reusable/` are documentation only.
 
-## MANDATORY pre-flight — do this before touching any file
+## MANDATORY pre-flight — execute every step, every time, before touching any file
 
-> **STOP.** Do not create, edit, or delete any file until all four steps below are complete.
+> **STOP.** Do not create, edit, or delete any file until all nine steps below are complete.
 > This applies to every change, no matter how small or "obvious".
 
 **Step 1 — Verify main is up to date**
 
 ```bash
-git checkout main && git pull origin main
+git checkout main
+git pull origin main
 ```
 
 **Step 2 — Create a GitHub issue**
+
+- Title: `<type>(<scope>): <short description>` using Conventional Commits format
+- Body: describe the problem, proposed solution, and acceptance criteria
+- Assign to yourself
+- Record the issue number — you will need it for every subsequent step
 
 ```bash
 gh issue create --title "<type>(scope): short description" --body "Problem, solution, acceptance criteria" --assignee @me
 ```
 
-Record the issue number. You cannot proceed without it.
-
 **Step 3 — Create a branch linked to that issue**
 
-```bash
-git checkout -b <type>/<issue-number>-<short-slug>
-# e.g. feat/42-add-pr-description-workflow
-```
+Branch naming format: `<type>/<issue-number>-<short-slug>`
 
 Valid types: `feat` `fix` `docs` `style` `refactor` `perf` `test` `build` `ci` `chore` `hotfix`
 
-**Step 4 — Make ALL changes on that branch, then open a PR**
+Examples: `feat/42-add-oauth-flow`, `fix/99-null-crash-on-login`, `chore/35-mvp-hardening`
 
 ```bash
-gh pr create --title "<type>(scope): description" --body "Closes #<issue-number>"
+git checkout -b <type>/<issue-number>-<short-slug>
+```
+
+**Step 4 — Implement the change**
+
+- Make only the changes required to resolve the issue
+- Do not refactor unrelated code or add unrequested features
+- If editing composed files is needed, edit the source (`instructions/`) and regenerate: `./scripts/compose.sh all`
+
+**Step 5 — Run local validation**
+
+```bash
+# Lint all shell scripts
+shellcheck scripts/*.sh
+
+# Re-compose and verify committed files match
+./scripts/compose.sh all
+./scripts/validate-composed.sh
+```
+
+Fix all errors before continuing. If `validate-composed.sh` reports stale files, commit the regenerated output before pushing.
+
+**Step 6 — Commit using Conventional Commits**
+
+```bash
+git add -A
+git commit -m "<type>(<scope>): <description>
+
+<body explaining what and why>
+
+Closes #<issue-number>"
+```
+
+> The subject line must be **≤ 100 characters** — `commitlint` enforces this in CI.
+
+**Step 7 — Push and open a Pull Request**
+
+```bash
+git push origin <branch-name>
+gh pr create \
+  --title "<type>(<scope>): <description>" \
+  --body "Closes #<issue-number>" \
+  --assignee @me
+```
+
+**Step 8 — Wait for all CI checks to pass**
+
+Do not merge until every check is green:
+- `Validate PR title (Conventional Commits)`
+- `Verify squash merge is enabled`
+- `Validate branch name`
+- `Check composed files are fresh`
+- `Lint shell scripts`
+- `Tiered Review` (must not have REQUEST_CHANGES findings)
+
+If any check fails, fix it on the branch and push again. Never bypass checks.
+
+**Step 9 — Merge via squash only**
+
+```bash
+gh pr merge <pr-number> --squash --delete-branch
 ```
 
 If you skipped any step, stop immediately, undo your changes (`git checkout main`), and restart from Step 1.
-The full governance workflow with validation steps is in `.github/prompts/implementation/governance.prompt.md`.
+
+**Non-negotiable rules:**
+- Never push directly to `main`
+- Never use `--force` on `main`
+- Never skip CI
+- Every change must trace to an issue number
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -82,7 +82,13 @@ Closes #<issue-number>"
 git push origin <branch-name>
 gh pr create \
   --title "<type>(<scope>): <description>" \
-  --body "Closes #<issue-number>" \
+  --body "Closes #<issue-number>
+
+## Changes
+- <what changed and why it matters>
+
+## Why
+- <problem solved or requirement met>" \
   --assignee @me
 ```
 
@@ -111,6 +117,21 @@ If you skipped any step, stop immediately, undo your changes (`git checkout main
 - Never use `--force` on `main`
 - Never skip CI
 - Every change must trace to an issue number
+
+**Project board:** `project-automation.yml` drives all card transitions automatically. Creating the
+issue (Step 2) adds it to **Todo**; pushing the branch moves it to **In Progress**; opening the PR
+moves it to **In Review**; merge moves it to **Done**. Never move cards manually.
+
+**Dependabot PRs:** When Dependabot opens a PR, follow these steps without exception:
+1. Wait for all CI checks to pass.
+2. **Patch or minor bump + green CI** — merge immediately:
+   ```bash
+   gh pr merge <pr-number> --squash --delete-branch
+   ```
+3. **Major version bump** — read the package changelog, check for breaking changes, update affected
+   code and tests on a new branch (following Steps 1–9 above), then merge.
+4. Never merge a Dependabot PR with failing CI.
+5. Never close a Dependabot PR without merging it unless the dependency is being intentionally removed.
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,7 +44,7 @@ gh pr create --title "<type>(scope): description" --body "Closes #<issue-number>
 ```
 
 If you skipped any step, stop immediately, undo your changes (`git checkout main`), and restart from Step 1.
-The full governance workflow with validation steps is in `.github/prompts/governance.prompt.md`.
+The full governance workflow with validation steps is in `.github/prompts/implementation/governance.prompt.md`.
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,6 +63,9 @@ shellcheck scripts/*.sh
 
 Fix all errors before continuing. If `validate-composed.sh` reports stale files, commit the regenerated output before pushing.
 
+Also run `#audit` on the branch before opening the PR. Run `#security-audit` on any change
+touching workflows, scripts, or permissions.
+
 **Step 6 — Commit using Conventional Commits**
 
 ```bash
@@ -143,3 +146,66 @@ moves it to **In Review**; merge moves it to **Done**. Never move cards manually
 4. Workflow files must use `workflow_call` trigger for reusable workflows.
 5. Follow conventional commits: `feat:`, `fix:`, `docs:`, `chore:`. Add a `scope` when applicable (e.g., `feat(frontend): add UI component`).
 6. Shell scripts must pass `shellcheck` with zero warnings and use `set -euo pipefail`. Never suppress a warning with `# shellcheck disable` as a first resort — fix the root cause. For SC2016 (dollar sign in single quotes), assign the string with double quotes and `\$` to produce a literal `$` without shell expansion (e.g. `Q="query(\$id:ID!){...}"`). Single-quoted assignment still triggers SC2016 — do not use it.
+
+## Available prompts
+
+Prompts are invocable agent workflows. Invoke with `#<name>` in VS Code Copilot Chat.
+**Use the correct prompt for every task — never implement, fix, scaffold, or review without it.**
+
+### Implementation
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#governance` | **Before any change** — full pre-flight (issue → branch → implement → validate → PR → merge) |
+| `#implement-feature` | Implementing a new feature end-to-end |
+| `#fix-bug` | Diagnosing and fixing a bug — reproduce first, then trace root cause |
+| `#write-tests` | Writing tests for existing code |
+| `#refactor` | Refactoring without changing observable behaviour |
+| `#write-docs` | Generating or updating README, API docs, ADRs, or changelogs |
+| `#create-adr` | Recording an architecture decision |
+| `#deploy` | Deploying a service — pre-deploy checks, health verification, rollback plan |
+| `#project-kickoff` | Bootstrapping a brand-new project from scratch |
+
+### Review — run before opening every PR
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#audit` | **Every PR** — validate the branch diff against all project standards |
+| `#security-audit` | Every PR touching workflows, scripts, or permissions |
+| `#performance-audit` | PRs touching data-intensive operations |
+| `#dependency-audit` | When adding, removing, or upgrading any dependency |
+
+### Scaffolds
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#crud-api` | Scaffolding a new CRUD resource |
+| `#auth` | Wiring authentication and authorisation |
+| `#database` | Setting up a new database, ORM, migrations |
+| `#frontend` | Scaffolding a new UI component |
+| `#background-jobs` | Scaffolding an async worker |
+| `#notifications` | Scaffolding notifications |
+| `#monorepo` | Scaffolding a multi-service monorepo |
+
+### Personas
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#architect` | System design, service decomposition, ADR facilitation |
+| `#principal-engineer` | Architecture review, abstraction quality, long-term maintainability |
+| `#devops-engineer` | CI/CD, containerisation, IaC, secrets management |
+| `#qa-engineer` | Test coverage, quality risks, edge cases |
+| `#product-manager` | PRDs, user stories, acceptance criteria |
+
+## Available skills
+
+Skills are specialised knowledge files. Load the relevant file at the start of any task in that
+domain. In this repo skills live in `skills/`.
+
+| Load this file | When |
+| -------------- | ---- |
+| `skills/test-generation.skill.md` | Writing any test suite |
+| `skills/code-analysis.skill.md` | Performing a deep code review or analysis |
+| `skills/api-design-review.skill.md` | Reviewing any PR that adds or changes API endpoints |
+| `skills/performance-profiling.skill.md` | Investigating or auditing performance |
+| `skills/data-migration.skill.md` | Working on any database schema migration or data backfill |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,8 +46,47 @@ git checkout -b <type>/<issue-number>-<short-slug>
 
 **Step 4 — Implement the change**
 
-- Make only the changes required to resolve the issue
-- Do not refactor unrelated code or add unrequested features
+Before writing any code, invoke the matching prompt for the task type. Do not start implementing
+without it.
+
+**Implementation prompts — invoke at the start of this step based on task type:**
+
+| Task | Invoke |
+| ---- | ------ |
+| Implementing a new feature | `#implement-feature` |
+| Fixing a bug | `#fix-bug` |
+| Writing or updating tests | `#write-tests` |
+| Refactoring existing code | `#refactor` |
+| Writing documentation | `#write-docs` |
+| Recording an architecture decision | `#create-adr` |
+| Deploying a service | `#deploy` |
+| Bootstrapping a new project | `#project-kickoff` |
+
+**Scaffold prompts — invoke at the start of this step when building a new system component:**
+
+| Building | Invoke |
+| -------- | ------ |
+| A new CRUD resource | `#crud-api` |
+| Authentication / authorisation | `#auth` |
+| A new database, ORM, or migrations | `#database` |
+| A new UI component | `#frontend` |
+| An async background worker | `#background-jobs` |
+| A notifications system | `#notifications` |
+| A multi-service monorepo | `#monorepo` |
+
+**Persona prompts — invoke concurrently when the work touches their domain:**
+
+| Domain | Invoke |
+| ------ | ------ |
+| System design, service decomposition, or ADR | `#architect` |
+| Architecture quality or long-term maintainability concerns | `#principal-engineer` |
+| CI/CD, infrastructure, containerisation, or deployment | `#devops-engineer` |
+| Test strategy, quality risks, or edge case coverage | `#qa-engineer` |
+| Requirements, user stories, or acceptance criteria | `#product-manager` |
+
+**Implementation rules (this repo):**
+- Make only the changes required to resolve the issue.
+- Do not refactor unrelated code or add unrequested features.
 - If editing composed files is needed, edit the source (`instructions/`) and regenerate: `./scripts/compose.sh all`
 
 **Step 5 — Run local validation**
@@ -152,10 +191,10 @@ moves it to **In Review**; merge moves it to **Done**. Never move cards manually
 
 ## Available prompts
 
-Prompts are invocable agent workflows. Invoke with `#<name>` in VS Code Copilot Chat.
-**Use the correct prompt for every task — never implement, fix, scaffold, or review without it.**
+Full reference of all available prompts. Invocation rules are in **Step 4** (implementation and
+scaffold prompts) and **Step 5** (review prompts). Use this table as a quick reference.
 
-### Implementation
+### Implementation — invoke at Step 4 before writing any code
 
 | Invoke | When to use |
 | ------ | ----------- |
@@ -169,7 +208,7 @@ Prompts are invocable agent workflows. Invoke with `#<name>` in VS Code Copilot 
 | `#deploy` | Deploying a service — pre-deploy checks, health verification, rollback plan |
 | `#project-kickoff` | Bootstrapping a brand-new project from scratch |
 
-### Review — run before opening every PR
+### Review — run at Step 5 before opening the PR
 
 | Invoke | When to use |
 | ------ | ----------- |
@@ -178,7 +217,7 @@ Prompts are invocable agent workflows. Invoke with `#<name>` in VS Code Copilot 
 | `#performance-audit` | PRs touching data-intensive operations |
 | `#dependency-audit` | When adding, removing, or upgrading any dependency |
 
-### Scaffolds
+### Scaffolds — invoke at Step 4 when building a new system component
 
 | Invoke | When to use |
 | ------ | ----------- |
@@ -190,7 +229,7 @@ Prompts are invocable agent workflows. Invoke with `#<name>` in VS Code Copilot 
 | `#notifications` | Scaffolding notifications |
 | `#monorepo` | Scaffolding a multi-service monorepo |
 
-### Personas
+### Personas — invoke concurrently at Step 4 when the work touches their domain
 
 | Invoke | When to use |
 | ------ | ----------- |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -84,6 +84,10 @@ without it.
 | Test strategy, quality risks, or edge case coverage | `#qa-engineer` |
 | Requirements, user stories, or acceptance criteria | `#product-manager` |
 
+> **Agent mode:** `#prompt-name` is human chat syntax. When running as an agent, use `read_file`
+> on each prompt's file path instead. The complete path-to-file dispatch tables for Steps 4 and 5
+> are in `.github/prompts/implementation/governance.prompt.md`.
+
 **Implementation rules (this repo):**
 - Make only the changes required to resolve the issue.
 - Do not refactor unrelated code or add unrequested features.
@@ -107,6 +111,9 @@ Run these review prompts before opening the PR — zero exceptions:
 - `#security-audit` — any PR touching workflows, scripts, permissions, auth, or external inputs.
 - `#dependency-audit` — any PR that adds, removes, or changes a dependency.
 - `#performance-audit` — any PR touching database queries, caching, or data-intensive operations.
+
+> **Agent mode:** Use `read_file` on the matching path from the Step 5 dispatch table in
+> `.github/prompts/implementation/governance.prompt.md`.
 
 **Step 6 — Commit using Conventional Commits**
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,8 +63,11 @@ shellcheck scripts/*.sh
 
 Fix all errors before continuing. If `validate-composed.sh` reports stale files, commit the regenerated output before pushing.
 
-Also run `#audit` on the branch before opening the PR. Run `#security-audit` on any change
-touching workflows, scripts, or permissions.
+Run these review prompts before opening the PR — zero exceptions:
+- `#audit` — every PR without exception.
+- `#security-audit` — any PR touching workflows, scripts, permissions, auth, or external inputs.
+- `#dependency-audit` — any PR that adds, removes, or changes a dependency.
+- `#performance-audit` — any PR touching database queries, caching, or data-intensive operations.
 
 **Step 6 — Commit using Conventional Commits**
 

--- a/.github/prompts/implementation/governance.prompt.md
+++ b/.github/prompts/implementation/governance.prompt.md
@@ -13,69 +13,135 @@ This file supplements Steps 4 and 5 with deterministic prompt dispatch for agent
 
 ---
 
-## Step 4 dispatch — implementation, scaffold, and persona prompts
+## Phase 0 — Collect context and build the todo list
 
-### 4a — Implementation prompt (required — pick exactly one)
+**Do this before touching any file or running any command.**
 
-Ask the user: **"What type of change are you making?"**
+Ask the user the three questions below **as numbered lists** so answers are unambiguous.
+If the user already provided sufficient context to answer a question, infer the answer and skip
+asking.
 
-| Task | Load this file |
-| ---- | -------------- |
-| Implementing a new feature | `.github/prompts/implementation/implement-feature.prompt.md` |
-| Fixing a bug | `.github/prompts/implementation/fix-bug.prompt.md` |
-| Writing or updating tests | `.github/prompts/implementation/write-tests.prompt.md` |
-| Refactoring existing code | `.github/prompts/implementation/refactor.prompt.md` |
-| Writing documentation | `.github/prompts/implementation/write-docs.prompt.md` |
-| Recording an architecture decision | `.github/prompts/implementation/create-adr.prompt.md` |
-| Deploying a service | `.github/prompts/implementation/deploy.prompt.md` |
-| Bootstrapping a new project | `.github/prompts/implementation/project-kickoff.prompt.md` |
+### Question 1 — Implementation type (required, pick exactly one)
 
-Use `read_file` on the matched path. Internalize and follow the loaded instructions before
-touching any file.
+Present as a numbered list:
 
-### 4b — Scaffold prompt (if building a new system component — may be none)
+1. Implementing a new feature
+2. Fixing a bug
+3. Writing or updating tests
+4. Refactoring existing code
+5. Writing documentation
+6. Recording an architecture decision
+7. Deploying a service
+8. Bootstrapping a new project
 
-Ask the user: **"Are you building a new system component? If yes, which one?"**
+### Question 2 — New system component (pick one, or 0 for none)
 
-| Component | Load this file |
-| --------- | -------------- |
-| CRUD resource | `.github/prompts/scaffolds/crud-api.prompt.md` |
-| Authentication / authorisation | `.github/prompts/scaffolds/auth.prompt.md` |
-| Database, ORM, or migrations | `.github/prompts/scaffolds/database.prompt.md` |
-| UI component | `.github/prompts/scaffolds/frontend.prompt.md` |
-| Async background worker | `.github/prompts/scaffolds/background-jobs.prompt.md` |
-| Notifications | `.github/prompts/scaffolds/notifications.prompt.md` |
-| Multi-service monorepo | `.github/prompts/scaffolds/monorepo.prompt.md` |
+Present as a numbered list:
 
-Use `read_file` on each matched path. Apply scaffold instructions alongside the implementation
-prompt.
+0. None — not building a new system component
+1. CRUD resource
+2. Authentication / authorisation
+3. Database, ORM, or migrations
+4. UI component
+5. Async background worker
+6. Notifications
+7. Multi-service monorepo
 
-### 4c — Persona prompts (load all that apply — may be none)
+### Question 3 — Domains touched (multi-select, or 0 for none)
 
-Ask the user: **"Which of these domains does your change touch? Select all that apply."**
+Present as a numbered list:
 
-| Domain | Load this file |
-| ------ | -------------- |
-| System design, service decomposition, or ADR | `.github/prompts/personas/architect.prompt.md` |
-| Architecture quality or long-term maintainability | `.github/prompts/personas/principal-engineer.prompt.md` |
-| CI/CD, infrastructure, containerisation, or deployment | `.github/prompts/personas/devops-engineer.prompt.md` |
-| Test strategy, quality risks, or edge case coverage | `.github/prompts/personas/qa-engineer.prompt.md` |
-| Requirements, user stories, or acceptance criteria | `.github/prompts/personas/product-manager.prompt.md` |
-
-Use `read_file` on each matched path. Apply persona instructions concurrently.
+0. None of the above
+1. System design, service decomposition, or ADR
+2. Architecture quality or long-term maintainability
+3. CI/CD, infrastructure, containerisation, or deployment
+4. Test strategy, quality risks, or edge case coverage
+5. Requirements, user stories, or acceptance criteria
 
 ---
 
-## Step 5 dispatch — review prompts
+## Dispatch tables
 
-Run all applicable review prompts before opening the PR. Use `read_file` on each matched path.
+Map each answer to a concrete file path. Use `read_file` on every matched path.
 
-| Prompt | Load this file | When |
-| ------ | -------------- | ---- |
-| audit | `.github/prompts/review/audit.prompt.md` | **Every PR** — no exceptions |
-| security-audit | `.github/prompts/review/security-audit.prompt.md` | Any PR touching auth, data access, external inputs, or dependencies |
-| dependency-audit | `.github/prompts/review/dependency-audit.prompt.md` | Any PR that adds, removes, or changes a dependency |
-| performance-audit | `.github/prompts/review/performance-audit.prompt.md` | Any PR touching database queries, caching, or frontend bundles |
+### Implementation (Question 1 → exactly one path)
+
+| Answer | Load this file |
+| ------ | -------------- |
+| 1 — New feature | `.github/prompts/implementation/implement-feature.prompt.md` |
+| 2 — Bug fix | `.github/prompts/implementation/fix-bug.prompt.md` |
+| 3 — Tests | `.github/prompts/implementation/write-tests.prompt.md` |
+| 4 — Refactor | `.github/prompts/implementation/refactor.prompt.md` |
+| 5 — Documentation | `.github/prompts/implementation/write-docs.prompt.md` |
+| 6 — ADR | `.github/prompts/implementation/create-adr.prompt.md` |
+| 7 — Deploy | `.github/prompts/implementation/deploy.prompt.md` |
+| 8 — New project | `.github/prompts/implementation/project-kickoff.prompt.md` |
+
+### Scaffold (Question 2 → zero or one path)
+
+| Answer | Load this file |
+| ------ | -------------- |
+| 1 — CRUD resource | `.github/prompts/scaffolds/crud-api.prompt.md` |
+| 2 — Auth | `.github/prompts/scaffolds/auth.prompt.md` |
+| 3 — Database | `.github/prompts/scaffolds/database.prompt.md` |
+| 4 — UI component | `.github/prompts/scaffolds/frontend.prompt.md` |
+| 5 — Background worker | `.github/prompts/scaffolds/background-jobs.prompt.md` |
+| 6 — Notifications | `.github/prompts/scaffolds/notifications.prompt.md` |
+| 7 — Monorepo | `.github/prompts/scaffolds/monorepo.prompt.md` |
+
+### Personas (Question 3 → zero or more paths)
+
+| Answer | Load this file |
+| ------ | -------------- |
+| 1 — System design / ADR | `.github/prompts/personas/architect.prompt.md` |
+| 2 — Architecture quality | `.github/prompts/personas/principal-engineer.prompt.md` |
+| 3 — CI/CD / infra | `.github/prompts/personas/devops-engineer.prompt.md` |
+| 4 — Test strategy | `.github/prompts/personas/qa-engineer.prompt.md` |
+| 5 — Requirements | `.github/prompts/personas/product-manager.prompt.md` |
+
+### Review prompts (Step 5 → always include audit; others depend on the change)
+
+| Load this file | When |
+| -------------- | ---- |
+| `.github/prompts/review/audit.prompt.md` | **Always** — every PR without exception |
+| `.github/prompts/review/security-audit.prompt.md` | PR touches auth, data access, external inputs, or dependencies |
+| `.github/prompts/review/dependency-audit.prompt.md` | PR adds, removes, or changes a dependency |
+| `.github/prompts/review/performance-audit.prompt.md` | PR touches database queries, caching, or frontend bundles |
+
+---
+
+## Build and present the todo list
+
+Once answers are collected, construct the **concrete** todo list below and present it to the user
+for confirmation before starting Step 1. Mark items off as they complete. Do not skip or reorder.
+
+The list is derived mechanically from the answers:
+- Include one `Step 4 — load` item per matched implementation path (always one).
+- Include one `Step 4 — load` item per matched scaffold path (zero or one).
+- Include one `Step 4 — load` item per matched persona path (zero or more, one per persona).
+- Include one `Step 5 — review` item per applicable review prompt (always includes audit).
+- All other steps are fixed and always present.
+
+```
+[ ] Step 1  — Verify main is up to date (git checkout main && git pull)
+[ ] Step 2  — Create GitHub issue
+[ ] Step 3  — Create branch (<type>/<issue-number>-<slug>)
+[ ] Step 4  — Load: <implementation prompt filename>          ← from Question 1
+[ ] Step 4  — Load: <scaffold prompt filename>                ← from Question 2 (omit if none)
+[ ] Step 4  — Load: <persona prompt filename>                 ← from Question 3 (one per selection, omit if none)
+[ ] Step 4  — Implement the change (following all loaded prompts)
+[ ] Step 5  — Run stack validation (lint, typecheck, tests)
+[ ] Step 5  — Review: audit                                   ← always
+[ ] Step 5  — Review: security-audit                          ← omit if not applicable
+[ ] Step 5  — Review: dependency-audit                        ← omit if not applicable
+[ ] Step 5  — Review: performance-audit                       ← omit if not applicable
+[ ] Step 6  — Commit (Conventional Commits, ≤ 100 char subject)
+[ ] Step 7  — Push and open Pull Request
+[ ] Step 8  — Wait for all CI checks to pass
+[ ] Step 9  — Merge via squash (gh pr merge <n> --squash --delete-branch)
+```
+
+Replace each `<placeholder>` with the actual filename from the dispatch tables above.
 
 ---
 

--- a/.github/prompts/implementation/governance.prompt.md
+++ b/.github/prompts/implementation/governance.prompt.md
@@ -1,119 +1,27 @@
 ---
 agent: agent
-description: "Full governance workflow — execute before making any change to this repository."
+description: "Governance workflow agent — execute before making any change to this repository."
 ---
 
 # Governance Workflow
 
-Execute **every step** in order before making any code or config change. Do not skip steps.
+> The authoritative steps live in `.github/copilot-instructions.md` under
+> **MANDATORY pre-flight**. That file is always loaded automatically; this prompt
+> is the interactive agent-mode entry point that drives you through those same steps.
 
-## Step 1 — Verify you are on main and it is up to date
+Execute the **MANDATORY pre-flight** from `.github/copilot-instructions.md` in full —
+all nine steps, in order. Do not skip any step.
 
-```bash
-git checkout main
-git pull origin main
+## PR body template (Step 7 supplement)
+
+When opening the pull request in Step 7, use this body structure:
+
 ```
-
-## Step 2 — Create a GitHub issue
-
-- Title: `<type>(<scope>): <short description>` using Conventional Commits format
-- Body: describe the problem, proposed solution, and acceptance criteria
-- Assign to yourself
-- Record the issue number — you will need it for the branch name
-
-```bash
-gh issue create --title "<type>(scope): description" --body "..." --assignee @me
-```
-
-## Step 3 — Create a feature branch from main
-
-Branch naming format: `<type>/<issue-number>-<short-slug>`
-
-Valid types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `hotfix`
-
-```bash
-git checkout -b <type>/<issue-number>-<slug>
-```
-
-Examples:
-- `feat/42-add-oauth-flow`
-- `fix/99-null-crash-on-login`
-- `chore/35-mvp-hardening`
-
-## Step 4 — Implement the change
-
-- Make only the changes required to resolve the issue
-- Do not refactor unrelated code or add unrequested features
-- Follow the rules in `.github/copilot-instructions.md`
-- If editing composed files is needed, edit the source (`instructions/`) and regenerate: `./scripts/compose.sh all`
-
-## Step 5 — Run local validation
-
-```bash
-# Lint all shell scripts for POSIX compliance and quoting issues
-shellcheck scripts/*.sh
-
-# Re-compose all stacks and verify committed files match (exits non-zero if stale)
-./scripts/compose.sh all
-./scripts/validate-composed.sh
-```
-
-Fix any errors before continuing. If `validate-composed.sh` reports stale files, commit the regenerated output before pushing.
-
-## Step 6 — Commit using Conventional Commits
-
-```bash
-git add -A
-git commit -m "<type>(<scope>): <description>
-
-<body explaining what and why>
-
-Closes #<issue-number>"
-```
-
-> **Title constraint:** The first line (`<type>(<scope>): <description>`) must be **≤ 100 characters** — `commitlint` enforces this in CI and will block the PR.
-
-## Step 7 — Push and open a Pull Request
-
-```bash
-git push origin <branch-name>
-gh pr create \
-  --title "<type>(<scope>): <description>" \
-  --body "Closes #<issue-number>
+Closes #<issue-number>
 
 ## Changes
 - <bullet list of what changed>
 
 ## Why
 - <reason>
-" \
-  --assignee @me
 ```
-
-## Step 8 — Wait for CI to pass
-
-All checks must be green before merging:
-- `Validate PR title (Conventional Commits)`
-- `Verify squash merge is enabled`
-- `Validate branch name`
-- `Check composed files are fresh`
-- `Lint shell scripts`
-- `Tiered Review` (automated code review — must not have REQUEST_CHANGES findings)
-
-If any check fails, fix it on the branch and push again. Do **not** bypass checks.
-
-## Step 9 — Merge via squash
-
-Use squash merge only. Merge commits and rebase merges are not allowed.
-
-```bash
-gh pr merge <pr-number> --squash --delete-branch
-```
-
----
-
-**Non-negotiable rules:**
-- Never push directly to `main`
-- Never use `--force` on `main`
-- Never skip CI
-- Every change must trace to an issue number

--- a/.github/prompts/implementation/governance.prompt.md
+++ b/.github/prompts/implementation/governance.prompt.md
@@ -5,16 +5,81 @@ description: "Governance workflow agent — execute before making any change to 
 
 # Governance Workflow
 
-> The authoritative steps live in `.github/copilot-instructions.md` under
-> **MANDATORY pre-flight**. That file is always loaded automatically; this prompt
-> is the interactive agent-mode entry point that drives you through those same steps.
+The authoritative 9-step pre-flight is in `.github/copilot-instructions.md` (auto-loaded every
+session). Execute it in full — all nine steps, in order. Do not skip any step.
 
-Execute the **MANDATORY pre-flight** from `.github/copilot-instructions.md` in full —
-all nine steps, in order. Do not skip any step.
+This file supplements Steps 4 and 5 with deterministic prompt dispatch for agent mode.
+`#prompt-name` in the pre-flight is human chat syntax. Agents must use `read_file` instead.
 
-## PR body template (Step 7 supplement)
+---
 
-When opening the pull request in Step 7, use this body structure:
+## Step 4 dispatch — implementation, scaffold, and persona prompts
+
+### 4a — Implementation prompt (required — pick exactly one)
+
+Ask the user: **"What type of change are you making?"**
+
+| Task | Load this file |
+| ---- | -------------- |
+| Implementing a new feature | `.github/prompts/implementation/implement-feature.prompt.md` |
+| Fixing a bug | `.github/prompts/implementation/fix-bug.prompt.md` |
+| Writing or updating tests | `.github/prompts/implementation/write-tests.prompt.md` |
+| Refactoring existing code | `.github/prompts/implementation/refactor.prompt.md` |
+| Writing documentation | `.github/prompts/implementation/write-docs.prompt.md` |
+| Recording an architecture decision | `.github/prompts/implementation/create-adr.prompt.md` |
+| Deploying a service | `.github/prompts/implementation/deploy.prompt.md` |
+| Bootstrapping a new project | `.github/prompts/implementation/project-kickoff.prompt.md` |
+
+Use `read_file` on the matched path. Internalize and follow the loaded instructions before
+touching any file.
+
+### 4b — Scaffold prompt (if building a new system component — may be none)
+
+Ask the user: **"Are you building a new system component? If yes, which one?"**
+
+| Component | Load this file |
+| --------- | -------------- |
+| CRUD resource | `.github/prompts/scaffolds/crud-api.prompt.md` |
+| Authentication / authorisation | `.github/prompts/scaffolds/auth.prompt.md` |
+| Database, ORM, or migrations | `.github/prompts/scaffolds/database.prompt.md` |
+| UI component | `.github/prompts/scaffolds/frontend.prompt.md` |
+| Async background worker | `.github/prompts/scaffolds/background-jobs.prompt.md` |
+| Notifications | `.github/prompts/scaffolds/notifications.prompt.md` |
+| Multi-service monorepo | `.github/prompts/scaffolds/monorepo.prompt.md` |
+
+Use `read_file` on each matched path. Apply scaffold instructions alongside the implementation
+prompt.
+
+### 4c — Persona prompts (load all that apply — may be none)
+
+Ask the user: **"Which of these domains does your change touch? Select all that apply."**
+
+| Domain | Load this file |
+| ------ | -------------- |
+| System design, service decomposition, or ADR | `.github/prompts/personas/architect.prompt.md` |
+| Architecture quality or long-term maintainability | `.github/prompts/personas/principal-engineer.prompt.md` |
+| CI/CD, infrastructure, containerisation, or deployment | `.github/prompts/personas/devops-engineer.prompt.md` |
+| Test strategy, quality risks, or edge case coverage | `.github/prompts/personas/qa-engineer.prompt.md` |
+| Requirements, user stories, or acceptance criteria | `.github/prompts/personas/product-manager.prompt.md` |
+
+Use `read_file` on each matched path. Apply persona instructions concurrently.
+
+---
+
+## Step 5 dispatch — review prompts
+
+Run all applicable review prompts before opening the PR. Use `read_file` on each matched path.
+
+| Prompt | Load this file | When |
+| ------ | -------------- | ---- |
+| audit | `.github/prompts/review/audit.prompt.md` | **Every PR** — no exceptions |
+| security-audit | `.github/prompts/review/security-audit.prompt.md` | Any PR touching auth, data access, external inputs, or dependencies |
+| dependency-audit | `.github/prompts/review/dependency-audit.prompt.md` | Any PR that adds, removes, or changes a dependency |
+| performance-audit | `.github/prompts/review/performance-audit.prompt.md` | Any PR touching database queries, caching, or frontend bundles |
+
+---
+
+## PR body template (Step 7)
 
 ```
 Closes #<issue-number>

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -19,7 +19,6 @@ on:
         default: 0
 
 permissions:
-  contents: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/merge-rules.yml
+++ b/.github/workflows/merge-rules.yml
@@ -53,8 +53,8 @@ jobs:
           echo '{"extends":["@commitlint/config-conventional"]}' > .commitlintrc.json
           echo "$PR_TITLE" | npx \
             --yes \
-            --package=@commitlint/cli@20.5.0 \
-            --package=@commitlint/config-conventional@20.5.0 \
+            --package=@commitlint/cli@20.5.3 \
+            --package=@commitlint/config-conventional@20.5.3 \
             commitlint --verbose
 
   squash-check:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up yamllint for YAML syntax validation
-        run: pip install --quiet "yamllint==1.35.1"
+        run: pip install --quiet "yamllint==1.38.0"
 
       - name: Validate YAML syntax across all workflow and config files
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,13 +2,13 @@
 # Lint all files manually: pre-commit run --all-files
 repos:
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.35.1
+    rev: v1.38.0
     hooks:
       - id: yamllint
         files: \.(yml|yaml)$
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.44.0
+    rev: v0.48.0
     hooks:
       - id: markdownlint
         files: \.md$

--- a/README.md
+++ b/README.md
@@ -15,7 +15,51 @@ adopt with a single bootstrap script.
 
 ## For teams adopting the standards
 
-### Quick start — bootstrap an existing repo
+### Quick start — green field (new project)
+
+Use this path when creating a brand-new repository from scratch.
+
+**Step 1 — Choose a stack**
+
+| Stack | Use when |
+| ----- | -------- |
+| `typescript` | Node.js APIs, full-stack apps, CLIs, or any JS/TS project |
+| `python` | Data pipelines, ML workloads, Django/FastAPI services |
+| `csharp` | .NET APIs, background services, or any C# project |
+| `typescript+python` | Projects with a TypeScript frontend and a Python backend |
+
+**Step 2 — Run the bootstrap script with `--create`**
+
+```bash
+git clone https://github.com/h-urena/copilot-agentic-standards.git
+./copilot-agentic-standards/scripts/onboard-repo.sh \
+  --repo ../my-new-project \
+  --stack typescript \
+  --create
+```
+
+The `--create` flag creates the GitHub repository, clones it locally, copies all standards files
+into it, creates conventional-commit labels, and provisions a GitHub Project board.
+
+**Step 3 — Complete post-setup (once, by the repo owner)**
+
+After the script finishes, do these steps once:
+
+1. **Enable branch protection on `main`** — follow the `gh api` commands printed by the script
+   at the end of its run.
+2. **Fill in `.github/project-context.md`** — open it and answer the prompted sections so agents
+   have project context without re-exploring the codebase every session.
+3. **Verify CI is green** — open the repo on GitHub and confirm the initial workflow runs pass.
+4. **Pin `pull-standards.yml`** — it was already copied; confirm it is enabled under
+   Settings → Actions → Workflows.
+
+---
+
+### Quick start — brown field (existing repo)
+
+Use this path when applying the standards to a repo that already exists.
+
+**Step 1 — Run the bootstrap script (no `--create` flag)**
 
 ```bash
 # Remotely (no clone needed)
@@ -27,8 +71,29 @@ git clone https://github.com/h-urena/copilot-agentic-standards.git
 ./copilot-agentic-standards/scripts/onboard-repo.sh --repo ../my-project --stack python
 ```
 
-The script copies everything listed in the table below into the target repo. Run it once; after
-that, `pull-standards.yml` keeps the repo in sync automatically.
+The script is idempotent — it skips files that already exist. Pass `--force` to overwrite
+existing files (use with care if you have customised them).
+
+**Step 2 — Review what was added**
+
+```bash
+cd ../my-project
+git status   # review the new/modified files before committing
+```
+
+Key files to inspect: `.github/copilot-instructions.md`, `.vscode/mcp.json`,
+`.github/workflows/pull-standards.yml`.
+
+**Step 3 — Complete post-setup (once, by the repo owner)**
+
+1. **Enable branch protection on `main`** — run the `gh api` commands printed by the script.
+2. **Fill in `.github/project-context.md`** — open it and fill in the project-specific sections.
+3. **Commit and push the bootstrapped files** — open a PR following the governance workflow
+   (`.github/prompts/implementation/governance.prompt.md`).
+4. **Verify CI is green** — confirm `pull-standards.yml` and any other new workflows pass.
+
+The script copies everything listed in the table below. Run it once; after that,
+`pull-standards.yml` keeps the repo in sync automatically.
 
 ### What gets copied by `onboard-repo.sh`
 
@@ -74,8 +139,34 @@ This produces:
 
 ### Keep standards in sync
 
-`pull-standards.yml` runs every Monday at 09:00 UTC and opens a PR when this repo changes.
-Enable it by running `onboard-repo.sh` once, or copy the workflow manually:
+`pull-standards.yml` runs every Monday at 09:00 UTC and opens a PR on the downstream repo when
+anything in this standards repo changes. Running `onboard-repo.sh` installs it automatically.
+
+**What it updates on each run:**
+
+- `.github/copilot-instructions.md` — from the latest composed file for the repo's stack
+- All domain instruction files (`api-design`, `auth-patterns`, `db-patterns`, etc.)
+- Code review checklists (generic + stack-specific)
+- All prompt files under `.github/prompts/`
+- Skill files under `.github/skills/`
+- PR description and merge-rules reusable workflows
+- Runtime version pins in `ci.yml` and `Dockerfile` (Python, Node.js, .NET) from `versions.json`
+
+**How to apply latest changes manually**
+
+1. Go to your repo on GitHub → Actions → `pull-standards` workflow.
+2. Click **Run workflow** → **Run workflow** (no inputs needed).
+3. The workflow opens a PR titled `chore: update standards from h-urena/copilot-agentic-standards`.
+4. Review the diff in that PR — it shows exactly which files changed.
+5. Merge the PR. Standards are now up to date.
+
+**Stack detection**
+
+The workflow reads the first five lines of `.github/copilot-instructions.md` for a comment like
+`<!-- Stack: typescript -->`. This comment is written by `onboard-repo.sh`. Do not remove or
+move it, or the sync workflow will silently skip updating the main instructions file.
+
+**If you don't yet have the workflow**
 
 ```bash
 cp workflows/sync/pull-standards.yml ../my-project/.github/workflows/pull-standards.yml
@@ -298,10 +389,7 @@ jobs:
 
 ### Contributing
 
-1. Follow `.github/prompts/governance.prompt.md` (create issue → branch → PR).
-2. Edit source files only — never files in `composed/`.
-3. Run `./scripts/compose.sh all && ./scripts/validate-composed.sh` before pushing.
-4. Open a PR with a Conventional Commits title: `type(scope): description`.
+Follow `.github/prompts/implementation/governance.prompt.md` for the full workflow (create issue → branch → implement → validate → PR). The governance prompt is the single source of truth — do not add inline steps here that can drift.
 
 ## License
 

--- a/composed/csharp-copilot-instructions.md
+++ b/composed/csharp-copilot-instructions.md
@@ -67,7 +67,8 @@ Run all of the following in order. Zero errors allowed — do not proceed with a
 2. **Type-check** — run the stack type checker in strict mode. Zero errors.
 3. **Tests** — run the full test suite. All must pass.
 4. **Security** — scan your diff for secrets, unsanitised inputs, broken auth, or injection vectors.
-   For significant changes invoke the `#security-audit` prompt before opening the PR.
+   Run `#security-audit` on any change touching auth, data access, or external inputs.
+   Run `#audit` on every PR before opening it.
 5. **Pre-commit hooks** — run `pre-commit run --all-files` if `.pre-commit-config.yaml` exists.
 6. **Composed files** — if the repo has `validate-composed.sh`, run it and commit any regenerated
    files before pushing.
@@ -251,6 +252,70 @@ When Dependabot opens a PR, follow these steps without exception:
 - Log errors with sufficient context for debugging (timestamp, request ID, stack trace).
 - Return meaningful error messages to callers; do not expose internal details to end users.
 - No problems stated in the 'Problems' tab should be ignored. If a problem is not actionable, it should be suppressed with a comment explaining why. Otherwise, all problems should be addressed before merging.
+
+## Available prompts
+
+Prompts are invocable agent workflows. Invoke with `#<name>` in VS Code Copilot Chat (the filename
+without extension). **Use the correct prompt for every task — never implement, fix, scaffold, or
+review without invoking the relevant prompt first.**
+
+### Implementation
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#governance` | **Before any change** — the full pre-flight workflow (issue → branch → implement → validate → PR → merge) |
+| `#implement-feature` | Implementing a new feature end-to-end |
+| `#fix-bug` | Diagnosing and fixing a bug — reproduce first, then trace root cause |
+| `#write-tests` | Writing tests for existing code |
+| `#refactor` | Refactoring without changing observable behaviour |
+| `#write-docs` | Generating or updating README, API docs, ADRs, or changelogs |
+| `#create-adr` | Recording an architecture decision in `docs/decisions/` |
+| `#deploy` | Deploying a service — pre-deploy checks, health verification, rollback plan |
+| `#project-kickoff` | Bootstrapping a brand-new project from scratch |
+
+### Review — run these before opening every PR
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#audit` | **Every PR** — validate the branch diff against all project standards |
+| `#security-audit` | Every PR touching auth, data access, external inputs, or dependencies |
+| `#performance-audit` | PRs touching database queries, caching, or frontend bundles |
+| `#dependency-audit` | When adding, removing, or upgrading any dependency |
+
+### Scaffolds
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#crud-api` | Scaffolding a new CRUD resource (routes, models, validation, tests, migrations) |
+| `#auth` | Wiring authentication and authorisation into a project |
+| `#database` | Setting up a new database, ORM, migrations, and health checks |
+| `#frontend` | Scaffolding a new UI component (structure, a11y, state management, tests) |
+| `#background-jobs` | Scaffolding an async worker (queue, retry policy, dead-letter handling) |
+| `#notifications` | Scaffolding email, webhook, or push notifications with retry and opt-out |
+| `#monorepo` | Scaffolding a multi-service monorepo layout with per-service CI |
+
+### Personas — invoke for a specialist review lens
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#architect` | System design, service decomposition, ADR facilitation |
+| `#principal-engineer` | Architecture review, abstraction quality, long-term maintainability |
+| `#devops-engineer` | CI/CD, containerisation, IaC, secrets management, deployment reliability |
+| `#qa-engineer` | Test coverage, quality risks, edge cases, regression strategy |
+| `#product-manager` | PRDs, user stories, acceptance criteria, feature scoping |
+
+## Available skills
+
+Skills are specialised knowledge files. Load the relevant file at the start of any task in that
+domain — do not rely on general knowledge alone. Skills live in `.github/skills/`.
+
+| Load this file | When |
+| -------------- | ---- |
+| `.github/skills/test-generation.skill.md` | Writing any test suite |
+| `.github/skills/code-analysis.skill.md` | Performing a deep code review or analysis |
+| `.github/skills/api-design-review.skill.md` | Reviewing any PR that adds or changes API endpoints |
+| `.github/skills/performance-profiling.skill.md` | Investigating or auditing performance |
+| `.github/skills/data-migration.skill.md` | Working on any database schema migration or data backfill |
 
 ---
 

--- a/composed/csharp-copilot-instructions.md
+++ b/composed/csharp-copilot-instructions.md
@@ -54,17 +54,6 @@ gh pr create --title "<type>(scope): description" --body "Closes #<issue-number>
 
 If you skipped any step, stop immediately, undo your changes (`git checkout main`), and restart from Step 1.
 
-## Agentic workflow
-
-Before making any code change, always execute these steps in order:
-
-1. **Create a GitHub issue** describing the problem or feature. Use `gh issue create` with a clear title and body.
-2. **Create a branch** from `main` following the naming format `<type>/<issue-number>-<short-slug>` (e.g. `feat/42-add-oauth-flow`). Use `git checkout -b`.
-3. **Make the changes** on that branch — never commit directly to `main`.
-4. **Open a PR** that references the issue with `Closes #N` in the body.
-
-Do not skip or defer any of these steps, even for small or "obvious" fixes.
-
 ## Branch strategy
 
 - **`main`** is the default, protected branch. All changes merge into `main` via pull request.

--- a/composed/csharp-copilot-instructions.md
+++ b/composed/csharp-copilot-instructions.md
@@ -93,6 +93,10 @@ without it.
 | Test strategy, quality risks, or edge case coverage | `#qa-engineer` |
 | Requirements, user stories, or acceptance criteria | `#product-manager` |
 
+> **Agent mode:** `#prompt-name` is human chat syntax. When running as an agent, use `read_file`
+> on each prompt's file path instead. The complete path-to-file dispatch tables for Steps 4 and 5
+> are in `.github/prompts/implementation/governance.prompt.md`.
+
 **Implementation rules:**
 - Make only the changes required to resolve the issue.
 - Do not refactor unrelated code or add unrequested features.
@@ -110,6 +114,8 @@ Run all of the following in order. Zero errors allowed — do not proceed with a
    - `#security-audit` — any PR touching auth, data access, external inputs, or dependencies.
    - `#dependency-audit` — any PR that adds, removes, or changes a dependency (lockfile, manifest, or version pin).
    - `#performance-audit` — any PR touching database queries, caching, pagination, or frontend bundle output.
+   > **Agent mode:** Use `read_file` on the matching path from the Step 5 dispatch table in
+   > `.github/prompts/implementation/governance.prompt.md`.
 5. **Pre-commit hooks** — run `pre-commit run --all-files` if `.pre-commit-config.yaml` exists.
 6. **Composed files** — if the repo has `validate-composed.sh`, run it and commit any regenerated
    files before pushing.

--- a/composed/csharp-copilot-instructions.md
+++ b/composed/csharp-copilot-instructions.md
@@ -66,9 +66,11 @@ Run all of the following in order. Zero errors allowed — do not proceed with a
 1. **Lint** — run the stack linter. Zero warnings. (Commands in the **Stack validation** section below.)
 2. **Type-check** — run the stack type checker in strict mode. Zero errors.
 3. **Tests** — run the full test suite. All must pass.
-4. **Security** — scan your diff for secrets, unsanitised inputs, broken auth, or injection vectors.
-   Run `#security-audit` on any change touching auth, data access, or external inputs.
-   Run `#audit` on every PR before opening it.
+4. **Review prompts** — run before opening the PR. Zero exceptions.
+   - `#audit` — every PR without exception.
+   - `#security-audit` — any PR touching auth, data access, external inputs, or dependencies.
+   - `#dependency-audit` — any PR that adds, removes, or changes a dependency (lockfile, manifest, or version pin).
+   - `#performance-audit` — any PR touching database queries, caching, pagination, or frontend bundle output.
 5. **Pre-commit hooks** — run `pre-commit run --all-files` if `.pre-commit-config.yaml` exists.
 6. **Composed files** — if the repo has `validate-composed.sh`, run it and commit any regenerated
    files before pushing.

--- a/composed/csharp-copilot-instructions.md
+++ b/composed/csharp-copilot-instructions.md
@@ -18,41 +18,93 @@ These are universal rules that apply to **every** repository regardless of langu
 - Do not leave dead code, commented-out code, or TODO comments without a linked issue.
 - Treat compiler/linter warnings as errors.
 
-## MANDATORY pre-flight — do this before touching any file
+## MANDATORY pre-flight — execute every step, every time, before touching any file
 
-> **STOP.** Do not create, edit, or delete any file until all four steps below are complete.
+> **STOP.** Do not create, edit, or delete any file until all nine steps below are complete.
 > This applies to every change, no matter how small or "obvious".
 
 **Step 1 — Verify main is up to date**
 
 ```bash
-git checkout main && git pull origin main
+git checkout main
+git pull origin main
 ```
 
 **Step 2 — Create a GitHub issue**
+
+- Title: `<type>(<scope>): <short description>` using Conventional Commits format
+- Body: describe the problem, proposed solution, and acceptance criteria
+- Assign to yourself
+- Record the issue number — you will need it for every subsequent step
 
 ```bash
 gh issue create --title "<type>(scope): short description" --body "Problem, solution, acceptance criteria" --assignee @me
 ```
 
-Record the issue number. You cannot proceed without it.
-
 **Step 3 — Create a branch linked to that issue**
 
-```bash
-git checkout -b <type>/<issue-number>-<short-slug>
-# e.g. feat/42-add-pr-description-workflow
-```
+Branch naming format: `<type>/<issue-number>-<short-slug>`
 
 Valid types: `feat` `fix` `docs` `style` `refactor` `perf` `test` `build` `ci` `chore` `hotfix`
 
-**Step 4 — Make ALL changes on that branch, then open a PR**
+Examples: `feat/42-add-oauth-flow`, `fix/99-null-crash-on-login`, `chore/35-mvp-hardening`
 
 ```bash
-gh pr create --title "<type>(scope): description" --body "Closes #<issue-number>"
+git checkout -b <type>/<issue-number>-<short-slug>
+```
+
+**Step 4 — Implement the change**
+
+- Make only the changes required to resolve the issue
+- Do not refactor unrelated code or add unrequested features
+- If modifying any source file that feeds a composed output, edit the source and regenerate
+
+**Step 5 — Run local validation**
+
+Run whatever validation the stack requires (linting, type-checking, tests) before committing.
+If the repo has a `validate-composed.sh` script, run it and fix any stale files.
+
+**Step 6 — Commit using Conventional Commits**
+
+```bash
+git add -A
+git commit -m "<type>(<scope>): <description>
+
+<body explaining what and why>
+
+Closes #<issue-number>"
+```
+
+> The subject line must be **≤ 100 characters** — `commitlint` enforces this in CI.
+
+**Step 7 — Push and open a Pull Request**
+
+```bash
+git push origin <branch-name>
+gh pr create \
+  --title "<type>(<scope>): <description>" \
+  --body "Closes #<issue-number>" \
+  --assignee @me
+```
+
+**Step 8 — Wait for all CI checks to pass**
+
+Do not merge until every required check is green. If any check fails, fix it on the branch and
+push again. Never bypass checks.
+
+**Step 9 — Merge via squash only**
+
+```bash
+gh pr merge <pr-number> --squash --delete-branch
 ```
 
 If you skipped any step, stop immediately, undo your changes (`git checkout main`), and restart from Step 1.
+
+**Non-negotiable rules:**
+- Never push directly to `main`
+- Never use `--force` on `main`
+- Never skip CI
+- Every change must trace to an issue number
 
 ## Branch strategy
 

--- a/composed/csharp-copilot-instructions.md
+++ b/composed/csharp-copilot-instructions.md
@@ -61,8 +61,16 @@ git checkout -b <type>/<issue-number>-<short-slug>
 
 **Step 5 — Run local validation**
 
-Run whatever validation the stack requires (linting, type-checking, tests) before committing.
-If the repo has a `validate-composed.sh` script, run it and fix any stale files.
+Run all of the following in order. Zero errors allowed — do not proceed with any failing check.
+
+1. **Lint** — run the stack linter. Zero warnings. (Commands in the **Stack validation** section below.)
+2. **Type-check** — run the stack type checker in strict mode. Zero errors.
+3. **Tests** — run the full test suite. All must pass.
+4. **Security** — scan your diff for secrets, unsanitised inputs, broken auth, or injection vectors.
+   For significant changes invoke the `#security-audit` prompt before opening the PR.
+5. **Pre-commit hooks** — run `pre-commit run --all-files` if `.pre-commit-config.yaml` exists.
+6. **Composed files** — if the repo has `validate-composed.sh`, run it and commit any regenerated
+   files before pushing.
 
 **Step 6 — Commit using Conventional Commits**
 
@@ -83,7 +91,13 @@ Closes #<issue-number>"
 git push origin <branch-name>
 gh pr create \
   --title "<type>(<scope>): <description>" \
-  --body "Closes #<issue-number>" \
+  --body "Closes #<issue-number>
+
+## Changes
+- <what changed and why it matters>
+
+## Why
+- <problem solved or requirement met>" \
   --assignee @me
 ```
 
@@ -142,14 +156,14 @@ If you skipped any step, stop immediately, undo your changes (`git checkout main
 
 ## Project board lifecycle
 
-Every issue moves through these statuses automatically via CI:
+All card transitions are **automated by `project-automation.yml`** — never move cards manually.
 
-| Status          | Trigger                                                                                                 |
+| Status          | Automated trigger                                                                                       |
 | --------------- | ------------------------------------------------------------------------------------------------------- |
-| **Todo**        | Issue created and added to the board                                                                    |
+| **Todo**        | Issue created (added to board automatically on `issues: opened`)                                        |
 | **In Progress** | Branch matching the issue number is pushed                                                              |
 | **In Review**   | PR is opened (owner is auto-assigned as reviewer)                                                       |
-| **Done**        | PR is approved → card moves to Done and squash auto-merge is armed; fires once all required checks pass |
+| **Done**        | PR is approved → squash auto-merge fires once all required checks pass                                 |
 
 ## Code review expectations
 
@@ -215,6 +229,20 @@ Every issue moves through these statuses automatically via CI:
 - Audit new dependencies before adding: check maintenance status, license, bundle size.
 - Prefer well-maintained, widely-used packages over obscure alternatives.
 - Remove unused dependencies promptly.
+
+## Dependabot PRs
+
+When Dependabot opens a PR, follow these steps without exception:
+
+1. Wait for all CI checks to pass.
+2. **Patch or minor bump + green CI** — merge immediately:
+   ```bash
+   gh pr merge <pr-number> --squash --delete-branch
+   ```
+3. **Major version bump** — read the package changelog, check for breaking changes, update affected
+   code and tests on a new branch (following Steps 1–9 of the pre-flight above), then merge.
+4. Never merge a Dependabot PR with failing CI.
+5. Never close a Dependabot PR without merging it unless the dependency is being intentionally removed.
 
 ## Error handling
 
@@ -293,6 +321,24 @@ Every issue moves through these statuses automatically via CI:
 - Every service exposes a `/health` endpoint. Register health checks with `AddHealthChecks()` and map them with `MapHealthChecks("/health")`.
 - Add dependency health checks (database, message broker, external APIs) so the health endpoint reflects true service readiness.
 - Use `Activity` and OpenTelemetry for distributed tracing in services that participate in a larger system.
+
+## Stack validation
+
+Run these commands in order at Step 5. All must pass with zero errors before committing.
+
+```bash
+# Format check — no unformatted files
+dotnet format --verify-no-changes
+
+# Build — zero errors and zero warnings
+dotnet build -warnaserror
+
+# Tests — all must pass
+dotnet test
+
+# Dependency audit — no known vulnerabilities
+dotnet list package --vulnerable
+```
 
 ## Testing
 

--- a/composed/csharp-copilot-instructions.md
+++ b/composed/csharp-copilot-instructions.md
@@ -55,9 +55,48 @@ git checkout -b <type>/<issue-number>-<short-slug>
 
 **Step 4 — Implement the change**
 
-- Make only the changes required to resolve the issue
-- Do not refactor unrelated code or add unrequested features
-- If modifying any source file that feeds a composed output, edit the source and regenerate
+Before writing any code, invoke the matching prompt for the task type. Do not start implementing
+without it.
+
+**Implementation prompts — invoke at the start of this step based on task type:**
+
+| Task | Invoke |
+| ---- | ------ |
+| Implementing a new feature | `#implement-feature` |
+| Fixing a bug | `#fix-bug` |
+| Writing or updating tests | `#write-tests` |
+| Refactoring existing code | `#refactor` |
+| Writing documentation | `#write-docs` |
+| Recording an architecture decision | `#create-adr` |
+| Deploying a service | `#deploy` |
+| Bootstrapping a new project | `#project-kickoff` |
+
+**Scaffold prompts — invoke at the start of this step when building a new system component:**
+
+| Building | Invoke |
+| -------- | ------ |
+| A new CRUD resource | `#crud-api` |
+| Authentication / authorisation | `#auth` |
+| A new database, ORM, or migrations | `#database` |
+| A new UI component | `#frontend` |
+| An async background worker | `#background-jobs` |
+| A notifications system | `#notifications` |
+| A multi-service monorepo | `#monorepo` |
+
+**Persona prompts — invoke concurrently when the work touches their domain:**
+
+| Domain | Invoke |
+| ------ | ------ |
+| System design, service decomposition, or ADR | `#architect` |
+| Architecture quality or long-term maintainability concerns | `#principal-engineer` |
+| CI/CD, infrastructure, containerisation, or deployment | `#devops-engineer` |
+| Test strategy, quality risks, or edge case coverage | `#qa-engineer` |
+| Requirements, user stories, or acceptance criteria | `#product-manager` |
+
+**Implementation rules:**
+- Make only the changes required to resolve the issue.
+- Do not refactor unrelated code or add unrequested features.
+- If modifying any source file that feeds a composed output, edit the source and regenerate.
 
 **Step 5 — Run local validation**
 
@@ -257,11 +296,10 @@ When Dependabot opens a PR, follow these steps without exception:
 
 ## Available prompts
 
-Prompts are invocable agent workflows. Invoke with `#<name>` in VS Code Copilot Chat (the filename
-without extension). **Use the correct prompt for every task — never implement, fix, scaffold, or
-review without invoking the relevant prompt first.**
+Full reference of all available prompts. Invocation rules are in **Step 4** (implementation and
+scaffold prompts) and **Step 5** (review prompts). Use this table as a quick reference.
 
-### Implementation
+### Implementation — invoke at Step 4 before writing any code
 
 | Invoke | When to use |
 | ------ | ----------- |
@@ -275,7 +313,7 @@ review without invoking the relevant prompt first.**
 | `#deploy` | Deploying a service — pre-deploy checks, health verification, rollback plan |
 | `#project-kickoff` | Bootstrapping a brand-new project from scratch |
 
-### Review — run these before opening every PR
+### Review — run at Step 5 before opening the PR
 
 | Invoke | When to use |
 | ------ | ----------- |
@@ -284,7 +322,7 @@ review without invoking the relevant prompt first.**
 | `#performance-audit` | PRs touching database queries, caching, or frontend bundles |
 | `#dependency-audit` | When adding, removing, or upgrading any dependency |
 
-### Scaffolds
+### Scaffolds — invoke at Step 4 when building a new system component
 
 | Invoke | When to use |
 | ------ | ----------- |
@@ -296,7 +334,7 @@ review without invoking the relevant prompt first.**
 | `#notifications` | Scaffolding email, webhook, or push notifications with retry and opt-out |
 | `#monorepo` | Scaffolding a multi-service monorepo layout with per-service CI |
 
-### Personas — invoke for a specialist review lens
+### Personas — invoke concurrently at Step 4 when the work touches their domain
 
 | Invoke | When to use |
 | ------ | ----------- |

--- a/composed/python+typescript-copilot-instructions.md
+++ b/composed/python+typescript-copilot-instructions.md
@@ -18,52 +18,155 @@ These are universal rules that apply to **every** repository regardless of langu
 - Do not leave dead code, commented-out code, or TODO comments without a linked issue.
 - Treat compiler/linter warnings as errors.
 
-## MANDATORY pre-flight — do this before touching any file
+## MANDATORY pre-flight — execute every step, every time, before touching any file
 
-> **STOP.** Do not create, edit, or delete any file until all four steps below are complete.
+> **STOP.** Do not create, edit, or delete any file until all nine steps below are complete.
 > This applies to every change, no matter how small or "obvious".
 
 **Step 1 — Verify main is up to date**
 
 ```bash
-git checkout main && git pull origin main
+git checkout main
+git pull origin main
 ```
 
 **Step 2 — Create a GitHub issue**
+
+- Title: `<type>(<scope>): <short description>` using Conventional Commits format
+- Body: describe the problem, proposed solution, and acceptance criteria
+- Assign to yourself
+- Record the issue number — you will need it for every subsequent step
 
 ```bash
 gh issue create --title "<type>(scope): short description" --body "Problem, solution, acceptance criteria" --assignee @me
 ```
 
-Record the issue number. You cannot proceed without it.
-
 **Step 3 — Create a branch linked to that issue**
 
-```bash
-git checkout -b <type>/<issue-number>-<short-slug>
-# e.g. feat/42-add-pr-description-workflow
-```
+Branch naming format: `<type>/<issue-number>-<short-slug>`
 
 Valid types: `feat` `fix` `docs` `style` `refactor` `perf` `test` `build` `ci` `chore` `hotfix`
 
-**Step 4 — Make ALL changes on that branch, then open a PR**
+Examples: `feat/42-add-oauth-flow`, `fix/99-null-crash-on-login`, `chore/35-mvp-hardening`
 
 ```bash
-gh pr create --title "<type>(scope): description" --body "Closes #<issue-number>"
+git checkout -b <type>/<issue-number>-<short-slug>
+```
+
+**Step 4 — Implement the change**
+
+Before writing any code, invoke the matching prompt for the task type. Do not start implementing
+without it.
+
+**Implementation prompts — invoke at the start of this step based on task type:**
+
+| Task | Invoke |
+| ---- | ------ |
+| Implementing a new feature | `#implement-feature` |
+| Fixing a bug | `#fix-bug` |
+| Writing or updating tests | `#write-tests` |
+| Refactoring existing code | `#refactor` |
+| Writing documentation | `#write-docs` |
+| Recording an architecture decision | `#create-adr` |
+| Deploying a service | `#deploy` |
+| Bootstrapping a new project | `#project-kickoff` |
+
+**Scaffold prompts — invoke at the start of this step when building a new system component:**
+
+| Building | Invoke |
+| -------- | ------ |
+| A new CRUD resource | `#crud-api` |
+| Authentication / authorisation | `#auth` |
+| A new database, ORM, or migrations | `#database` |
+| A new UI component | `#frontend` |
+| An async background worker | `#background-jobs` |
+| A notifications system | `#notifications` |
+| A multi-service monorepo | `#monorepo` |
+
+**Persona prompts — invoke concurrently when the work touches their domain:**
+
+| Domain | Invoke |
+| ------ | ------ |
+| System design, service decomposition, or ADR | `#architect` |
+| Architecture quality or long-term maintainability concerns | `#principal-engineer` |
+| CI/CD, infrastructure, containerisation, or deployment | `#devops-engineer` |
+| Test strategy, quality risks, or edge case coverage | `#qa-engineer` |
+| Requirements, user stories, or acceptance criteria | `#product-manager` |
+
+> **Agent mode:** `#prompt-name` is human chat syntax. When running as an agent, use `read_file`
+> on each prompt's file path instead. The complete path-to-file dispatch tables for Steps 4 and 5
+> are in `.github/prompts/implementation/governance.prompt.md`.
+
+**Implementation rules:**
+- Make only the changes required to resolve the issue.
+- Do not refactor unrelated code or add unrequested features.
+- If modifying any source file that feeds a composed output, edit the source and regenerate.
+
+**Step 5 — Run local validation**
+
+Run all of the following in order. Zero errors allowed — do not proceed with any failing check.
+
+1. **Lint** — run the stack linter. Zero warnings. (Commands in the **Stack validation** section below.)
+2. **Type-check** — run the stack type checker in strict mode. Zero errors.
+3. **Tests** — run the full test suite. All must pass.
+4. **Review prompts** — run before opening the PR. Zero exceptions.
+   - `#audit` — every PR without exception.
+   - `#security-audit` — any PR touching auth, data access, external inputs, or dependencies.
+   - `#dependency-audit` — any PR that adds, removes, or changes a dependency (lockfile, manifest, or version pin).
+   - `#performance-audit` — any PR touching database queries, caching, pagination, or frontend bundle output.
+   > **Agent mode:** Use `read_file` on the matching path from the Step 5 dispatch table in
+   > `.github/prompts/implementation/governance.prompt.md`.
+5. **Pre-commit hooks** — run `pre-commit run --all-files` if `.pre-commit-config.yaml` exists.
+6. **Composed files** — if the repo has `validate-composed.sh`, run it and commit any regenerated
+   files before pushing.
+
+**Step 6 — Commit using Conventional Commits**
+
+```bash
+git add -A
+git commit -m "<type>(<scope>): <description>
+
+<body explaining what and why>
+
+Closes #<issue-number>"
+```
+
+> The subject line must be **≤ 100 characters** — `commitlint` enforces this in CI.
+
+**Step 7 — Push and open a Pull Request**
+
+```bash
+git push origin <branch-name>
+gh pr create \
+  --title "<type>(<scope>): <description>" \
+  --body "Closes #<issue-number>
+
+## Changes
+- <what changed and why it matters>
+
+## Why
+- <problem solved or requirement met>" \
+  --assignee @me
+```
+
+**Step 8 — Wait for all CI checks to pass**
+
+Do not merge until every required check is green. If any check fails, fix it on the branch and
+push again. Never bypass checks.
+
+**Step 9 — Merge via squash only**
+
+```bash
+gh pr merge <pr-number> --squash --delete-branch
 ```
 
 If you skipped any step, stop immediately, undo your changes (`git checkout main`), and restart from Step 1.
 
-## Agentic workflow
-
-Before making any code change, always execute these steps in order:
-
-1. **Create a GitHub issue** describing the problem or feature. Use `gh issue create` with a clear title and body.
-2. **Create a branch** from `main` following the naming format `<type>/<issue-number>-<short-slug>` (e.g. `feat/42-add-oauth-flow`). Use `git checkout -b`.
-3. **Make the changes** on that branch — never commit directly to `main`.
-4. **Open a PR** that references the issue with `Closes #N` in the body.
-
-Do not skip or defer any of these steps, even for small or "obvious" fixes.
+**Non-negotiable rules:**
+- Never push directly to `main`
+- Never use `--force` on `main`
+- Never skip CI
+- Every change must trace to an issue number
 
 ## Branch strategy
 
@@ -101,14 +204,14 @@ Do not skip or defer any of these steps, even for small or "obvious" fixes.
 
 ## Project board lifecycle
 
-Every issue moves through these statuses automatically via CI:
+All card transitions are **automated by `project-automation.yml`** — never move cards manually.
 
-| Status          | Trigger                                                                                                 |
+| Status          | Automated trigger                                                                                       |
 | --------------- | ------------------------------------------------------------------------------------------------------- |
-| **Todo**        | Issue created and added to the board                                                                    |
+| **Todo**        | Issue created (added to board automatically on `issues: opened`)                                        |
 | **In Progress** | Branch matching the issue number is pushed                                                              |
 | **In Review**   | PR is opened (owner is auto-assigned as reviewer)                                                       |
-| **Done**        | PR is approved → card moves to Done and squash auto-merge is armed; fires once all required checks pass |
+| **Done**        | PR is approved → squash auto-merge fires once all required checks pass                                 |
 
 ## Code review expectations
 
@@ -175,6 +278,20 @@ Every issue moves through these statuses automatically via CI:
 - Prefer well-maintained, widely-used packages over obscure alternatives.
 - Remove unused dependencies promptly.
 
+## Dependabot PRs
+
+When Dependabot opens a PR, follow these steps without exception:
+
+1. Wait for all CI checks to pass.
+2. **Patch or minor bump + green CI** — merge immediately:
+   ```bash
+   gh pr merge <pr-number> --squash --delete-branch
+   ```
+3. **Major version bump** — read the package changelog, check for breaking changes, update affected
+   code and tests on a new branch (following Steps 1–9 of the pre-flight above), then merge.
+4. Never merge a Dependabot PR with failing CI.
+5. Never close a Dependabot PR without merging it unless the dependency is being intentionally removed.
+
 ## Error handling
 
 - Handle errors explicitly. Do not swallow exceptions silently.
@@ -182,6 +299,69 @@ Every issue moves through these statuses automatically via CI:
 - Log errors with sufficient context for debugging (timestamp, request ID, stack trace).
 - Return meaningful error messages to callers; do not expose internal details to end users.
 - No problems stated in the 'Problems' tab should be ignored. If a problem is not actionable, it should be suppressed with a comment explaining why. Otherwise, all problems should be addressed before merging.
+
+## Available prompts
+
+Full reference of all available prompts. Invocation rules are in **Step 4** (implementation and
+scaffold prompts) and **Step 5** (review prompts). Use this table as a quick reference.
+
+### Implementation — invoke at Step 4 before writing any code
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#governance` | **Before any change** — the full pre-flight workflow (issue → branch → implement → validate → PR → merge) |
+| `#implement-feature` | Implementing a new feature end-to-end |
+| `#fix-bug` | Diagnosing and fixing a bug — reproduce first, then trace root cause |
+| `#write-tests` | Writing tests for existing code |
+| `#refactor` | Refactoring without changing observable behaviour |
+| `#write-docs` | Generating or updating README, API docs, ADRs, or changelogs |
+| `#create-adr` | Recording an architecture decision in `docs/decisions/` |
+| `#deploy` | Deploying a service — pre-deploy checks, health verification, rollback plan |
+| `#project-kickoff` | Bootstrapping a brand-new project from scratch |
+
+### Review — run at Step 5 before opening the PR
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#audit` | **Every PR** — validate the branch diff against all project standards |
+| `#security-audit` | Every PR touching auth, data access, external inputs, or dependencies |
+| `#performance-audit` | PRs touching database queries, caching, or frontend bundles |
+| `#dependency-audit` | When adding, removing, or upgrading any dependency |
+
+### Scaffolds — invoke at Step 4 when building a new system component
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#crud-api` | Scaffolding a new CRUD resource (routes, models, validation, tests, migrations) |
+| `#auth` | Wiring authentication and authorisation into a project |
+| `#database` | Setting up a new database, ORM, migrations, and health checks |
+| `#frontend` | Scaffolding a new UI component (structure, a11y, state management, tests) |
+| `#background-jobs` | Scaffolding an async worker (queue, retry policy, dead-letter handling) |
+| `#notifications` | Scaffolding email, webhook, or push notifications with retry and opt-out |
+| `#monorepo` | Scaffolding a multi-service monorepo layout with per-service CI |
+
+### Personas — invoke concurrently at Step 4 when the work touches their domain
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#architect` | System design, service decomposition, ADR facilitation |
+| `#principal-engineer` | Architecture review, abstraction quality, long-term maintainability |
+| `#devops-engineer` | CI/CD, containerisation, IaC, secrets management, deployment reliability |
+| `#qa-engineer` | Test coverage, quality risks, edge cases, regression strategy |
+| `#product-manager` | PRDs, user stories, acceptance criteria, feature scoping |
+
+## Available skills
+
+Skills are specialised knowledge files. Load the relevant file at the start of any task in that
+domain — do not rely on general knowledge alone. Skills live in `.github/skills/`.
+
+| Load this file | When |
+| -------------- | ---- |
+| `.github/skills/test-generation.skill.md` | Writing any test suite |
+| `.github/skills/code-analysis.skill.md` | Performing a deep code review or analysis |
+| `.github/skills/api-design-review.skill.md` | Reviewing any PR that adds or changes API endpoints |
+| `.github/skills/performance-profiling.skill.md` | Investigating or auditing performance |
+| `.github/skills/data-migration.skill.md` | Working on any database schema migration or data backfill |
 
 ---
 
@@ -237,6 +417,27 @@ Every issue moves through these statuses automatically via CI:
 ## Configuration
 
 - Validate all environment variables at application startup using `pydantic-settings`. Never read `os.environ` inline at call sites — fail fast on missing or malformed config.
+
+## Stack validation
+
+Run these commands in order at Step 5. All must pass with zero errors before committing.
+
+```bash
+# Lint — zero errors
+ruff check .
+
+# Format check — no unformatted files
+ruff format --check .
+
+# Type-check — zero errors (strict mode)
+mypy .
+
+# Tests — all must pass
+pytest
+
+# Dependency audit — no known vulnerabilities
+pip-audit
+```
 
 ## Testing
 
@@ -310,6 +511,26 @@ Every issue moves through these statuses automatically via CI:
 - Use **`pino`** for structured JSON logging in Node.js services. Never use `console.log` in production code paths.
 - Pass a child logger with request-scoped context (request ID, user ID) through the call chain — use `logger.child({ requestId })` per request.
 - Log at appropriate levels. Never log PII, tokens, or full request/response bodies.
+
+## Stack validation
+
+Run these commands in order at Step 5. All must pass with zero errors before committing.
+
+```bash
+# Lint — zero ESLint errors or warnings
+npm run lint
+
+# Type-check — zero TypeScript errors (strict mode)
+npm run typecheck
+
+# Tests — all must pass
+npm test
+
+# Dependency audit — no high or critical vulnerabilities
+npm audit --audit-level=high
+```
+
+If the project uses `pnpm`, substitute `pnpm run lint`, `pnpm run typecheck`, `pnpm test`, `pnpm audit --audit-level=high`.
 
 ## Testing
 

--- a/composed/python-copilot-instructions.md
+++ b/composed/python-copilot-instructions.md
@@ -67,7 +67,8 @@ Run all of the following in order. Zero errors allowed — do not proceed with a
 2. **Type-check** — run the stack type checker in strict mode. Zero errors.
 3. **Tests** — run the full test suite. All must pass.
 4. **Security** — scan your diff for secrets, unsanitised inputs, broken auth, or injection vectors.
-   For significant changes invoke the `#security-audit` prompt before opening the PR.
+   Run `#security-audit` on any change touching auth, data access, or external inputs.
+   Run `#audit` on every PR before opening it.
 5. **Pre-commit hooks** — run `pre-commit run --all-files` if `.pre-commit-config.yaml` exists.
 6. **Composed files** — if the repo has `validate-composed.sh`, run it and commit any regenerated
    files before pushing.
@@ -251,6 +252,70 @@ When Dependabot opens a PR, follow these steps without exception:
 - Log errors with sufficient context for debugging (timestamp, request ID, stack trace).
 - Return meaningful error messages to callers; do not expose internal details to end users.
 - No problems stated in the 'Problems' tab should be ignored. If a problem is not actionable, it should be suppressed with a comment explaining why. Otherwise, all problems should be addressed before merging.
+
+## Available prompts
+
+Prompts are invocable agent workflows. Invoke with `#<name>` in VS Code Copilot Chat (the filename
+without extension). **Use the correct prompt for every task — never implement, fix, scaffold, or
+review without invoking the relevant prompt first.**
+
+### Implementation
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#governance` | **Before any change** — the full pre-flight workflow (issue → branch → implement → validate → PR → merge) |
+| `#implement-feature` | Implementing a new feature end-to-end |
+| `#fix-bug` | Diagnosing and fixing a bug — reproduce first, then trace root cause |
+| `#write-tests` | Writing tests for existing code |
+| `#refactor` | Refactoring without changing observable behaviour |
+| `#write-docs` | Generating or updating README, API docs, ADRs, or changelogs |
+| `#create-adr` | Recording an architecture decision in `docs/decisions/` |
+| `#deploy` | Deploying a service — pre-deploy checks, health verification, rollback plan |
+| `#project-kickoff` | Bootstrapping a brand-new project from scratch |
+
+### Review — run these before opening every PR
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#audit` | **Every PR** — validate the branch diff against all project standards |
+| `#security-audit` | Every PR touching auth, data access, external inputs, or dependencies |
+| `#performance-audit` | PRs touching database queries, caching, or frontend bundles |
+| `#dependency-audit` | When adding, removing, or upgrading any dependency |
+
+### Scaffolds
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#crud-api` | Scaffolding a new CRUD resource (routes, models, validation, tests, migrations) |
+| `#auth` | Wiring authentication and authorisation into a project |
+| `#database` | Setting up a new database, ORM, migrations, and health checks |
+| `#frontend` | Scaffolding a new UI component (structure, a11y, state management, tests) |
+| `#background-jobs` | Scaffolding an async worker (queue, retry policy, dead-letter handling) |
+| `#notifications` | Scaffolding email, webhook, or push notifications with retry and opt-out |
+| `#monorepo` | Scaffolding a multi-service monorepo layout with per-service CI |
+
+### Personas — invoke for a specialist review lens
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#architect` | System design, service decomposition, ADR facilitation |
+| `#principal-engineer` | Architecture review, abstraction quality, long-term maintainability |
+| `#devops-engineer` | CI/CD, containerisation, IaC, secrets management, deployment reliability |
+| `#qa-engineer` | Test coverage, quality risks, edge cases, regression strategy |
+| `#product-manager` | PRDs, user stories, acceptance criteria, feature scoping |
+
+## Available skills
+
+Skills are specialised knowledge files. Load the relevant file at the start of any task in that
+domain — do not rely on general knowledge alone. Skills live in `.github/skills/`.
+
+| Load this file | When |
+| -------------- | ---- |
+| `.github/skills/test-generation.skill.md` | Writing any test suite |
+| `.github/skills/code-analysis.skill.md` | Performing a deep code review or analysis |
+| `.github/skills/api-design-review.skill.md` | Reviewing any PR that adds or changes API endpoints |
+| `.github/skills/performance-profiling.skill.md` | Investigating or auditing performance |
+| `.github/skills/data-migration.skill.md` | Working on any database schema migration or data backfill |
 
 ---
 

--- a/composed/python-copilot-instructions.md
+++ b/composed/python-copilot-instructions.md
@@ -54,17 +54,6 @@ gh pr create --title "<type>(scope): description" --body "Closes #<issue-number>
 
 If you skipped any step, stop immediately, undo your changes (`git checkout main`), and restart from Step 1.
 
-## Agentic workflow
-
-Before making any code change, always execute these steps in order:
-
-1. **Create a GitHub issue** describing the problem or feature. Use `gh issue create` with a clear title and body.
-2. **Create a branch** from `main` following the naming format `<type>/<issue-number>-<short-slug>` (e.g. `feat/42-add-oauth-flow`). Use `git checkout -b`.
-3. **Make the changes** on that branch — never commit directly to `main`.
-4. **Open a PR** that references the issue with `Closes #N` in the body.
-
-Do not skip or defer any of these steps, even for small or "obvious" fixes.
-
 ## Branch strategy
 
 - **`main`** is the default, protected branch. All changes merge into `main` via pull request.

--- a/composed/python-copilot-instructions.md
+++ b/composed/python-copilot-instructions.md
@@ -93,6 +93,10 @@ without it.
 | Test strategy, quality risks, or edge case coverage | `#qa-engineer` |
 | Requirements, user stories, or acceptance criteria | `#product-manager` |
 
+> **Agent mode:** `#prompt-name` is human chat syntax. When running as an agent, use `read_file`
+> on each prompt's file path instead. The complete path-to-file dispatch tables for Steps 4 and 5
+> are in `.github/prompts/implementation/governance.prompt.md`.
+
 **Implementation rules:**
 - Make only the changes required to resolve the issue.
 - Do not refactor unrelated code or add unrequested features.
@@ -110,6 +114,8 @@ Run all of the following in order. Zero errors allowed — do not proceed with a
    - `#security-audit` — any PR touching auth, data access, external inputs, or dependencies.
    - `#dependency-audit` — any PR that adds, removes, or changes a dependency (lockfile, manifest, or version pin).
    - `#performance-audit` — any PR touching database queries, caching, pagination, or frontend bundle output.
+   > **Agent mode:** Use `read_file` on the matching path from the Step 5 dispatch table in
+   > `.github/prompts/implementation/governance.prompt.md`.
 5. **Pre-commit hooks** — run `pre-commit run --all-files` if `.pre-commit-config.yaml` exists.
 6. **Composed files** — if the repo has `validate-composed.sh`, run it and commit any regenerated
    files before pushing.

--- a/composed/python-copilot-instructions.md
+++ b/composed/python-copilot-instructions.md
@@ -66,9 +66,11 @@ Run all of the following in order. Zero errors allowed — do not proceed with a
 1. **Lint** — run the stack linter. Zero warnings. (Commands in the **Stack validation** section below.)
 2. **Type-check** — run the stack type checker in strict mode. Zero errors.
 3. **Tests** — run the full test suite. All must pass.
-4. **Security** — scan your diff for secrets, unsanitised inputs, broken auth, or injection vectors.
-   Run `#security-audit` on any change touching auth, data access, or external inputs.
-   Run `#audit` on every PR before opening it.
+4. **Review prompts** — run before opening the PR. Zero exceptions.
+   - `#audit` — every PR without exception.
+   - `#security-audit` — any PR touching auth, data access, external inputs, or dependencies.
+   - `#dependency-audit` — any PR that adds, removes, or changes a dependency (lockfile, manifest, or version pin).
+   - `#performance-audit` — any PR touching database queries, caching, pagination, or frontend bundle output.
 5. **Pre-commit hooks** — run `pre-commit run --all-files` if `.pre-commit-config.yaml` exists.
 6. **Composed files** — if the repo has `validate-composed.sh`, run it and commit any regenerated
    files before pushing.

--- a/composed/python-copilot-instructions.md
+++ b/composed/python-copilot-instructions.md
@@ -18,41 +18,93 @@ These are universal rules that apply to **every** repository regardless of langu
 - Do not leave dead code, commented-out code, or TODO comments without a linked issue.
 - Treat compiler/linter warnings as errors.
 
-## MANDATORY pre-flight — do this before touching any file
+## MANDATORY pre-flight — execute every step, every time, before touching any file
 
-> **STOP.** Do not create, edit, or delete any file until all four steps below are complete.
+> **STOP.** Do not create, edit, or delete any file until all nine steps below are complete.
 > This applies to every change, no matter how small or "obvious".
 
 **Step 1 — Verify main is up to date**
 
 ```bash
-git checkout main && git pull origin main
+git checkout main
+git pull origin main
 ```
 
 **Step 2 — Create a GitHub issue**
+
+- Title: `<type>(<scope>): <short description>` using Conventional Commits format
+- Body: describe the problem, proposed solution, and acceptance criteria
+- Assign to yourself
+- Record the issue number — you will need it for every subsequent step
 
 ```bash
 gh issue create --title "<type>(scope): short description" --body "Problem, solution, acceptance criteria" --assignee @me
 ```
 
-Record the issue number. You cannot proceed without it.
-
 **Step 3 — Create a branch linked to that issue**
 
-```bash
-git checkout -b <type>/<issue-number>-<short-slug>
-# e.g. feat/42-add-pr-description-workflow
-```
+Branch naming format: `<type>/<issue-number>-<short-slug>`
 
 Valid types: `feat` `fix` `docs` `style` `refactor` `perf` `test` `build` `ci` `chore` `hotfix`
 
-**Step 4 — Make ALL changes on that branch, then open a PR**
+Examples: `feat/42-add-oauth-flow`, `fix/99-null-crash-on-login`, `chore/35-mvp-hardening`
 
 ```bash
-gh pr create --title "<type>(scope): description" --body "Closes #<issue-number>"
+git checkout -b <type>/<issue-number>-<short-slug>
+```
+
+**Step 4 — Implement the change**
+
+- Make only the changes required to resolve the issue
+- Do not refactor unrelated code or add unrequested features
+- If modifying any source file that feeds a composed output, edit the source and regenerate
+
+**Step 5 — Run local validation**
+
+Run whatever validation the stack requires (linting, type-checking, tests) before committing.
+If the repo has a `validate-composed.sh` script, run it and fix any stale files.
+
+**Step 6 — Commit using Conventional Commits**
+
+```bash
+git add -A
+git commit -m "<type>(<scope>): <description>
+
+<body explaining what and why>
+
+Closes #<issue-number>"
+```
+
+> The subject line must be **≤ 100 characters** — `commitlint` enforces this in CI.
+
+**Step 7 — Push and open a Pull Request**
+
+```bash
+git push origin <branch-name>
+gh pr create \
+  --title "<type>(<scope>): <description>" \
+  --body "Closes #<issue-number>" \
+  --assignee @me
+```
+
+**Step 8 — Wait for all CI checks to pass**
+
+Do not merge until every required check is green. If any check fails, fix it on the branch and
+push again. Never bypass checks.
+
+**Step 9 — Merge via squash only**
+
+```bash
+gh pr merge <pr-number> --squash --delete-branch
 ```
 
 If you skipped any step, stop immediately, undo your changes (`git checkout main`), and restart from Step 1.
+
+**Non-negotiable rules:**
+- Never push directly to `main`
+- Never use `--force` on `main`
+- Never skip CI
+- Every change must trace to an issue number
 
 ## Branch strategy
 

--- a/composed/python-copilot-instructions.md
+++ b/composed/python-copilot-instructions.md
@@ -55,9 +55,48 @@ git checkout -b <type>/<issue-number>-<short-slug>
 
 **Step 4 — Implement the change**
 
-- Make only the changes required to resolve the issue
-- Do not refactor unrelated code or add unrequested features
-- If modifying any source file that feeds a composed output, edit the source and regenerate
+Before writing any code, invoke the matching prompt for the task type. Do not start implementing
+without it.
+
+**Implementation prompts — invoke at the start of this step based on task type:**
+
+| Task | Invoke |
+| ---- | ------ |
+| Implementing a new feature | `#implement-feature` |
+| Fixing a bug | `#fix-bug` |
+| Writing or updating tests | `#write-tests` |
+| Refactoring existing code | `#refactor` |
+| Writing documentation | `#write-docs` |
+| Recording an architecture decision | `#create-adr` |
+| Deploying a service | `#deploy` |
+| Bootstrapping a new project | `#project-kickoff` |
+
+**Scaffold prompts — invoke at the start of this step when building a new system component:**
+
+| Building | Invoke |
+| -------- | ------ |
+| A new CRUD resource | `#crud-api` |
+| Authentication / authorisation | `#auth` |
+| A new database, ORM, or migrations | `#database` |
+| A new UI component | `#frontend` |
+| An async background worker | `#background-jobs` |
+| A notifications system | `#notifications` |
+| A multi-service monorepo | `#monorepo` |
+
+**Persona prompts — invoke concurrently when the work touches their domain:**
+
+| Domain | Invoke |
+| ------ | ------ |
+| System design, service decomposition, or ADR | `#architect` |
+| Architecture quality or long-term maintainability concerns | `#principal-engineer` |
+| CI/CD, infrastructure, containerisation, or deployment | `#devops-engineer` |
+| Test strategy, quality risks, or edge case coverage | `#qa-engineer` |
+| Requirements, user stories, or acceptance criteria | `#product-manager` |
+
+**Implementation rules:**
+- Make only the changes required to resolve the issue.
+- Do not refactor unrelated code or add unrequested features.
+- If modifying any source file that feeds a composed output, edit the source and regenerate.
 
 **Step 5 — Run local validation**
 
@@ -257,11 +296,10 @@ When Dependabot opens a PR, follow these steps without exception:
 
 ## Available prompts
 
-Prompts are invocable agent workflows. Invoke with `#<name>` in VS Code Copilot Chat (the filename
-without extension). **Use the correct prompt for every task — never implement, fix, scaffold, or
-review without invoking the relevant prompt first.**
+Full reference of all available prompts. Invocation rules are in **Step 4** (implementation and
+scaffold prompts) and **Step 5** (review prompts). Use this table as a quick reference.
 
-### Implementation
+### Implementation — invoke at Step 4 before writing any code
 
 | Invoke | When to use |
 | ------ | ----------- |
@@ -275,7 +313,7 @@ review without invoking the relevant prompt first.**
 | `#deploy` | Deploying a service — pre-deploy checks, health verification, rollback plan |
 | `#project-kickoff` | Bootstrapping a brand-new project from scratch |
 
-### Review — run these before opening every PR
+### Review — run at Step 5 before opening the PR
 
 | Invoke | When to use |
 | ------ | ----------- |
@@ -284,7 +322,7 @@ review without invoking the relevant prompt first.**
 | `#performance-audit` | PRs touching database queries, caching, or frontend bundles |
 | `#dependency-audit` | When adding, removing, or upgrading any dependency |
 
-### Scaffolds
+### Scaffolds — invoke at Step 4 when building a new system component
 
 | Invoke | When to use |
 | ------ | ----------- |
@@ -296,7 +334,7 @@ review without invoking the relevant prompt first.**
 | `#notifications` | Scaffolding email, webhook, or push notifications with retry and opt-out |
 | `#monorepo` | Scaffolding a multi-service monorepo layout with per-service CI |
 
-### Personas — invoke for a specialist review lens
+### Personas — invoke concurrently at Step 4 when the work touches their domain
 
 | Invoke | When to use |
 | ------ | ----------- |

--- a/composed/python-copilot-instructions.md
+++ b/composed/python-copilot-instructions.md
@@ -61,8 +61,16 @@ git checkout -b <type>/<issue-number>-<short-slug>
 
 **Step 5 — Run local validation**
 
-Run whatever validation the stack requires (linting, type-checking, tests) before committing.
-If the repo has a `validate-composed.sh` script, run it and fix any stale files.
+Run all of the following in order. Zero errors allowed — do not proceed with any failing check.
+
+1. **Lint** — run the stack linter. Zero warnings. (Commands in the **Stack validation** section below.)
+2. **Type-check** — run the stack type checker in strict mode. Zero errors.
+3. **Tests** — run the full test suite. All must pass.
+4. **Security** — scan your diff for secrets, unsanitised inputs, broken auth, or injection vectors.
+   For significant changes invoke the `#security-audit` prompt before opening the PR.
+5. **Pre-commit hooks** — run `pre-commit run --all-files` if `.pre-commit-config.yaml` exists.
+6. **Composed files** — if the repo has `validate-composed.sh`, run it and commit any regenerated
+   files before pushing.
 
 **Step 6 — Commit using Conventional Commits**
 
@@ -83,7 +91,13 @@ Closes #<issue-number>"
 git push origin <branch-name>
 gh pr create \
   --title "<type>(<scope>): <description>" \
-  --body "Closes #<issue-number>" \
+  --body "Closes #<issue-number>
+
+## Changes
+- <what changed and why it matters>
+
+## Why
+- <problem solved or requirement met>" \
   --assignee @me
 ```
 
@@ -142,14 +156,14 @@ If you skipped any step, stop immediately, undo your changes (`git checkout main
 
 ## Project board lifecycle
 
-Every issue moves through these statuses automatically via CI:
+All card transitions are **automated by `project-automation.yml`** — never move cards manually.
 
-| Status          | Trigger                                                                                                 |
+| Status          | Automated trigger                                                                                       |
 | --------------- | ------------------------------------------------------------------------------------------------------- |
-| **Todo**        | Issue created and added to the board                                                                    |
+| **Todo**        | Issue created (added to board automatically on `issues: opened`)                                        |
 | **In Progress** | Branch matching the issue number is pushed                                                              |
 | **In Review**   | PR is opened (owner is auto-assigned as reviewer)                                                       |
-| **Done**        | PR is approved → card moves to Done and squash auto-merge is armed; fires once all required checks pass |
+| **Done**        | PR is approved → squash auto-merge fires once all required checks pass                                 |
 
 ## Code review expectations
 
@@ -216,6 +230,20 @@ Every issue moves through these statuses automatically via CI:
 - Prefer well-maintained, widely-used packages over obscure alternatives.
 - Remove unused dependencies promptly.
 
+## Dependabot PRs
+
+When Dependabot opens a PR, follow these steps without exception:
+
+1. Wait for all CI checks to pass.
+2. **Patch or minor bump + green CI** — merge immediately:
+   ```bash
+   gh pr merge <pr-number> --squash --delete-branch
+   ```
+3. **Major version bump** — read the package changelog, check for breaking changes, update affected
+   code and tests on a new branch (following Steps 1–9 of the pre-flight above), then merge.
+4. Never merge a Dependabot PR with failing CI.
+5. Never close a Dependabot PR without merging it unless the dependency is being intentionally removed.
+
 ## Error handling
 
 - Handle errors explicitly. Do not swallow exceptions silently.
@@ -278,6 +306,27 @@ Every issue moves through these statuses automatically via CI:
 ## Configuration
 
 - Validate all environment variables at application startup using `pydantic-settings`. Never read `os.environ` inline at call sites — fail fast on missing or malformed config.
+
+## Stack validation
+
+Run these commands in order at Step 5. All must pass with zero errors before committing.
+
+```bash
+# Lint — zero errors
+ruff check .
+
+# Format check — no unformatted files
+ruff format --check .
+
+# Type-check — zero errors (strict mode)
+mypy .
+
+# Tests — all must pass
+pytest
+
+# Dependency audit — no known vulnerabilities
+pip-audit
+```
 
 ## Testing
 

--- a/composed/typescript-copilot-instructions.md
+++ b/composed/typescript-copilot-instructions.md
@@ -67,7 +67,8 @@ Run all of the following in order. Zero errors allowed — do not proceed with a
 2. **Type-check** — run the stack type checker in strict mode. Zero errors.
 3. **Tests** — run the full test suite. All must pass.
 4. **Security** — scan your diff for secrets, unsanitised inputs, broken auth, or injection vectors.
-   For significant changes invoke the `#security-audit` prompt before opening the PR.
+   Run `#security-audit` on any change touching auth, data access, or external inputs.
+   Run `#audit` on every PR before opening it.
 5. **Pre-commit hooks** — run `pre-commit run --all-files` if `.pre-commit-config.yaml` exists.
 6. **Composed files** — if the repo has `validate-composed.sh`, run it and commit any regenerated
    files before pushing.
@@ -251,6 +252,70 @@ When Dependabot opens a PR, follow these steps without exception:
 - Log errors with sufficient context for debugging (timestamp, request ID, stack trace).
 - Return meaningful error messages to callers; do not expose internal details to end users.
 - No problems stated in the 'Problems' tab should be ignored. If a problem is not actionable, it should be suppressed with a comment explaining why. Otherwise, all problems should be addressed before merging.
+
+## Available prompts
+
+Prompts are invocable agent workflows. Invoke with `#<name>` in VS Code Copilot Chat (the filename
+without extension). **Use the correct prompt for every task — never implement, fix, scaffold, or
+review without invoking the relevant prompt first.**
+
+### Implementation
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#governance` | **Before any change** — the full pre-flight workflow (issue → branch → implement → validate → PR → merge) |
+| `#implement-feature` | Implementing a new feature end-to-end |
+| `#fix-bug` | Diagnosing and fixing a bug — reproduce first, then trace root cause |
+| `#write-tests` | Writing tests for existing code |
+| `#refactor` | Refactoring without changing observable behaviour |
+| `#write-docs` | Generating or updating README, API docs, ADRs, or changelogs |
+| `#create-adr` | Recording an architecture decision in `docs/decisions/` |
+| `#deploy` | Deploying a service — pre-deploy checks, health verification, rollback plan |
+| `#project-kickoff` | Bootstrapping a brand-new project from scratch |
+
+### Review — run these before opening every PR
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#audit` | **Every PR** — validate the branch diff against all project standards |
+| `#security-audit` | Every PR touching auth, data access, external inputs, or dependencies |
+| `#performance-audit` | PRs touching database queries, caching, or frontend bundles |
+| `#dependency-audit` | When adding, removing, or upgrading any dependency |
+
+### Scaffolds
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#crud-api` | Scaffolding a new CRUD resource (routes, models, validation, tests, migrations) |
+| `#auth` | Wiring authentication and authorisation into a project |
+| `#database` | Setting up a new database, ORM, migrations, and health checks |
+| `#frontend` | Scaffolding a new UI component (structure, a11y, state management, tests) |
+| `#background-jobs` | Scaffolding an async worker (queue, retry policy, dead-letter handling) |
+| `#notifications` | Scaffolding email, webhook, or push notifications with retry and opt-out |
+| `#monorepo` | Scaffolding a multi-service monorepo layout with per-service CI |
+
+### Personas — invoke for a specialist review lens
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#architect` | System design, service decomposition, ADR facilitation |
+| `#principal-engineer` | Architecture review, abstraction quality, long-term maintainability |
+| `#devops-engineer` | CI/CD, containerisation, IaC, secrets management, deployment reliability |
+| `#qa-engineer` | Test coverage, quality risks, edge cases, regression strategy |
+| `#product-manager` | PRDs, user stories, acceptance criteria, feature scoping |
+
+## Available skills
+
+Skills are specialised knowledge files. Load the relevant file at the start of any task in that
+domain — do not rely on general knowledge alone. Skills live in `.github/skills/`.
+
+| Load this file | When |
+| -------------- | ---- |
+| `.github/skills/test-generation.skill.md` | Writing any test suite |
+| `.github/skills/code-analysis.skill.md` | Performing a deep code review or analysis |
+| `.github/skills/api-design-review.skill.md` | Reviewing any PR that adds or changes API endpoints |
+| `.github/skills/performance-profiling.skill.md` | Investigating or auditing performance |
+| `.github/skills/data-migration.skill.md` | Working on any database schema migration or data backfill |
 
 ---
 

--- a/composed/typescript-copilot-instructions.md
+++ b/composed/typescript-copilot-instructions.md
@@ -54,17 +54,6 @@ gh pr create --title "<type>(scope): description" --body "Closes #<issue-number>
 
 If you skipped any step, stop immediately, undo your changes (`git checkout main`), and restart from Step 1.
 
-## Agentic workflow
-
-Before making any code change, always execute these steps in order:
-
-1. **Create a GitHub issue** describing the problem or feature. Use `gh issue create` with a clear title and body.
-2. **Create a branch** from `main` following the naming format `<type>/<issue-number>-<short-slug>` (e.g. `feat/42-add-oauth-flow`). Use `git checkout -b`.
-3. **Make the changes** on that branch — never commit directly to `main`.
-4. **Open a PR** that references the issue with `Closes #N` in the body.
-
-Do not skip or defer any of these steps, even for small or "obvious" fixes.
-
 ## Branch strategy
 
 - **`main`** is the default, protected branch. All changes merge into `main` via pull request.

--- a/composed/typescript-copilot-instructions.md
+++ b/composed/typescript-copilot-instructions.md
@@ -61,8 +61,16 @@ git checkout -b <type>/<issue-number>-<short-slug>
 
 **Step 5 — Run local validation**
 
-Run whatever validation the stack requires (linting, type-checking, tests) before committing.
-If the repo has a `validate-composed.sh` script, run it and fix any stale files.
+Run all of the following in order. Zero errors allowed — do not proceed with any failing check.
+
+1. **Lint** — run the stack linter. Zero warnings. (Commands in the **Stack validation** section below.)
+2. **Type-check** — run the stack type checker in strict mode. Zero errors.
+3. **Tests** — run the full test suite. All must pass.
+4. **Security** — scan your diff for secrets, unsanitised inputs, broken auth, or injection vectors.
+   For significant changes invoke the `#security-audit` prompt before opening the PR.
+5. **Pre-commit hooks** — run `pre-commit run --all-files` if `.pre-commit-config.yaml` exists.
+6. **Composed files** — if the repo has `validate-composed.sh`, run it and commit any regenerated
+   files before pushing.
 
 **Step 6 — Commit using Conventional Commits**
 
@@ -83,7 +91,13 @@ Closes #<issue-number>"
 git push origin <branch-name>
 gh pr create \
   --title "<type>(<scope>): <description>" \
-  --body "Closes #<issue-number>" \
+  --body "Closes #<issue-number>
+
+## Changes
+- <what changed and why it matters>
+
+## Why
+- <problem solved or requirement met>" \
   --assignee @me
 ```
 
@@ -142,14 +156,14 @@ If you skipped any step, stop immediately, undo your changes (`git checkout main
 
 ## Project board lifecycle
 
-Every issue moves through these statuses automatically via CI:
+All card transitions are **automated by `project-automation.yml`** — never move cards manually.
 
-| Status          | Trigger                                                                                                 |
+| Status          | Automated trigger                                                                                       |
 | --------------- | ------------------------------------------------------------------------------------------------------- |
-| **Todo**        | Issue created and added to the board                                                                    |
+| **Todo**        | Issue created (added to board automatically on `issues: opened`)                                        |
 | **In Progress** | Branch matching the issue number is pushed                                                              |
 | **In Review**   | PR is opened (owner is auto-assigned as reviewer)                                                       |
-| **Done**        | PR is approved → card moves to Done and squash auto-merge is armed; fires once all required checks pass |
+| **Done**        | PR is approved → squash auto-merge fires once all required checks pass                                 |
 
 ## Code review expectations
 
@@ -216,6 +230,20 @@ Every issue moves through these statuses automatically via CI:
 - Prefer well-maintained, widely-used packages over obscure alternatives.
 - Remove unused dependencies promptly.
 
+## Dependabot PRs
+
+When Dependabot opens a PR, follow these steps without exception:
+
+1. Wait for all CI checks to pass.
+2. **Patch or minor bump + green CI** — merge immediately:
+   ```bash
+   gh pr merge <pr-number> --squash --delete-branch
+   ```
+3. **Major version bump** — read the package changelog, check for breaking changes, update affected
+   code and tests on a new branch (following Steps 1–9 of the pre-flight above), then merge.
+4. Never merge a Dependabot PR with failing CI.
+5. Never close a Dependabot PR without merging it unless the dependency is being intentionally removed.
+
 ## Error handling
 
 - Handle errors explicitly. Do not swallow exceptions silently.
@@ -274,6 +302,26 @@ Every issue moves through these statuses automatically via CI:
 - Use **`pino`** for structured JSON logging in Node.js services. Never use `console.log` in production code paths.
 - Pass a child logger with request-scoped context (request ID, user ID) through the call chain — use `logger.child({ requestId })` per request.
 - Log at appropriate levels. Never log PII, tokens, or full request/response bodies.
+
+## Stack validation
+
+Run these commands in order at Step 5. All must pass with zero errors before committing.
+
+```bash
+# Lint — zero ESLint errors or warnings
+npm run lint
+
+# Type-check — zero TypeScript errors (strict mode)
+npm run typecheck
+
+# Tests — all must pass
+npm test
+
+# Dependency audit — no high or critical vulnerabilities
+npm audit --audit-level=high
+```
+
+If the project uses `pnpm`, substitute `pnpm run lint`, `pnpm run typecheck`, `pnpm test`, `pnpm audit --audit-level=high`.
 
 ## Testing
 

--- a/composed/typescript-copilot-instructions.md
+++ b/composed/typescript-copilot-instructions.md
@@ -93,6 +93,10 @@ without it.
 | Test strategy, quality risks, or edge case coverage | `#qa-engineer` |
 | Requirements, user stories, or acceptance criteria | `#product-manager` |
 
+> **Agent mode:** `#prompt-name` is human chat syntax. When running as an agent, use `read_file`
+> on each prompt's file path instead. The complete path-to-file dispatch tables for Steps 4 and 5
+> are in `.github/prompts/implementation/governance.prompt.md`.
+
 **Implementation rules:**
 - Make only the changes required to resolve the issue.
 - Do not refactor unrelated code or add unrequested features.
@@ -110,6 +114,8 @@ Run all of the following in order. Zero errors allowed — do not proceed with a
    - `#security-audit` — any PR touching auth, data access, external inputs, or dependencies.
    - `#dependency-audit` — any PR that adds, removes, or changes a dependency (lockfile, manifest, or version pin).
    - `#performance-audit` — any PR touching database queries, caching, pagination, or frontend bundle output.
+   > **Agent mode:** Use `read_file` on the matching path from the Step 5 dispatch table in
+   > `.github/prompts/implementation/governance.prompt.md`.
 5. **Pre-commit hooks** — run `pre-commit run --all-files` if `.pre-commit-config.yaml` exists.
 6. **Composed files** — if the repo has `validate-composed.sh`, run it and commit any regenerated
    files before pushing.

--- a/composed/typescript-copilot-instructions.md
+++ b/composed/typescript-copilot-instructions.md
@@ -66,9 +66,11 @@ Run all of the following in order. Zero errors allowed — do not proceed with a
 1. **Lint** — run the stack linter. Zero warnings. (Commands in the **Stack validation** section below.)
 2. **Type-check** — run the stack type checker in strict mode. Zero errors.
 3. **Tests** — run the full test suite. All must pass.
-4. **Security** — scan your diff for secrets, unsanitised inputs, broken auth, or injection vectors.
-   Run `#security-audit` on any change touching auth, data access, or external inputs.
-   Run `#audit` on every PR before opening it.
+4. **Review prompts** — run before opening the PR. Zero exceptions.
+   - `#audit` — every PR without exception.
+   - `#security-audit` — any PR touching auth, data access, external inputs, or dependencies.
+   - `#dependency-audit` — any PR that adds, removes, or changes a dependency (lockfile, manifest, or version pin).
+   - `#performance-audit` — any PR touching database queries, caching, pagination, or frontend bundle output.
 5. **Pre-commit hooks** — run `pre-commit run --all-files` if `.pre-commit-config.yaml` exists.
 6. **Composed files** — if the repo has `validate-composed.sh`, run it and commit any regenerated
    files before pushing.

--- a/composed/typescript-copilot-instructions.md
+++ b/composed/typescript-copilot-instructions.md
@@ -18,41 +18,93 @@ These are universal rules that apply to **every** repository regardless of langu
 - Do not leave dead code, commented-out code, or TODO comments without a linked issue.
 - Treat compiler/linter warnings as errors.
 
-## MANDATORY pre-flight — do this before touching any file
+## MANDATORY pre-flight — execute every step, every time, before touching any file
 
-> **STOP.** Do not create, edit, or delete any file until all four steps below are complete.
+> **STOP.** Do not create, edit, or delete any file until all nine steps below are complete.
 > This applies to every change, no matter how small or "obvious".
 
 **Step 1 — Verify main is up to date**
 
 ```bash
-git checkout main && git pull origin main
+git checkout main
+git pull origin main
 ```
 
 **Step 2 — Create a GitHub issue**
+
+- Title: `<type>(<scope>): <short description>` using Conventional Commits format
+- Body: describe the problem, proposed solution, and acceptance criteria
+- Assign to yourself
+- Record the issue number — you will need it for every subsequent step
 
 ```bash
 gh issue create --title "<type>(scope): short description" --body "Problem, solution, acceptance criteria" --assignee @me
 ```
 
-Record the issue number. You cannot proceed without it.
-
 **Step 3 — Create a branch linked to that issue**
 
-```bash
-git checkout -b <type>/<issue-number>-<short-slug>
-# e.g. feat/42-add-pr-description-workflow
-```
+Branch naming format: `<type>/<issue-number>-<short-slug>`
 
 Valid types: `feat` `fix` `docs` `style` `refactor` `perf` `test` `build` `ci` `chore` `hotfix`
 
-**Step 4 — Make ALL changes on that branch, then open a PR**
+Examples: `feat/42-add-oauth-flow`, `fix/99-null-crash-on-login`, `chore/35-mvp-hardening`
 
 ```bash
-gh pr create --title "<type>(scope): description" --body "Closes #<issue-number>"
+git checkout -b <type>/<issue-number>-<short-slug>
+```
+
+**Step 4 — Implement the change**
+
+- Make only the changes required to resolve the issue
+- Do not refactor unrelated code or add unrequested features
+- If modifying any source file that feeds a composed output, edit the source and regenerate
+
+**Step 5 — Run local validation**
+
+Run whatever validation the stack requires (linting, type-checking, tests) before committing.
+If the repo has a `validate-composed.sh` script, run it and fix any stale files.
+
+**Step 6 — Commit using Conventional Commits**
+
+```bash
+git add -A
+git commit -m "<type>(<scope>): <description>
+
+<body explaining what and why>
+
+Closes #<issue-number>"
+```
+
+> The subject line must be **≤ 100 characters** — `commitlint` enforces this in CI.
+
+**Step 7 — Push and open a Pull Request**
+
+```bash
+git push origin <branch-name>
+gh pr create \
+  --title "<type>(<scope>): <description>" \
+  --body "Closes #<issue-number>" \
+  --assignee @me
+```
+
+**Step 8 — Wait for all CI checks to pass**
+
+Do not merge until every required check is green. If any check fails, fix it on the branch and
+push again. Never bypass checks.
+
+**Step 9 — Merge via squash only**
+
+```bash
+gh pr merge <pr-number> --squash --delete-branch
 ```
 
 If you skipped any step, stop immediately, undo your changes (`git checkout main`), and restart from Step 1.
+
+**Non-negotiable rules:**
+- Never push directly to `main`
+- Never use `--force` on `main`
+- Never skip CI
+- Every change must trace to an issue number
 
 ## Branch strategy
 

--- a/composed/typescript-copilot-instructions.md
+++ b/composed/typescript-copilot-instructions.md
@@ -55,9 +55,48 @@ git checkout -b <type>/<issue-number>-<short-slug>
 
 **Step 4 — Implement the change**
 
-- Make only the changes required to resolve the issue
-- Do not refactor unrelated code or add unrequested features
-- If modifying any source file that feeds a composed output, edit the source and regenerate
+Before writing any code, invoke the matching prompt for the task type. Do not start implementing
+without it.
+
+**Implementation prompts — invoke at the start of this step based on task type:**
+
+| Task | Invoke |
+| ---- | ------ |
+| Implementing a new feature | `#implement-feature` |
+| Fixing a bug | `#fix-bug` |
+| Writing or updating tests | `#write-tests` |
+| Refactoring existing code | `#refactor` |
+| Writing documentation | `#write-docs` |
+| Recording an architecture decision | `#create-adr` |
+| Deploying a service | `#deploy` |
+| Bootstrapping a new project | `#project-kickoff` |
+
+**Scaffold prompts — invoke at the start of this step when building a new system component:**
+
+| Building | Invoke |
+| -------- | ------ |
+| A new CRUD resource | `#crud-api` |
+| Authentication / authorisation | `#auth` |
+| A new database, ORM, or migrations | `#database` |
+| A new UI component | `#frontend` |
+| An async background worker | `#background-jobs` |
+| A notifications system | `#notifications` |
+| A multi-service monorepo | `#monorepo` |
+
+**Persona prompts — invoke concurrently when the work touches their domain:**
+
+| Domain | Invoke |
+| ------ | ------ |
+| System design, service decomposition, or ADR | `#architect` |
+| Architecture quality or long-term maintainability concerns | `#principal-engineer` |
+| CI/CD, infrastructure, containerisation, or deployment | `#devops-engineer` |
+| Test strategy, quality risks, or edge case coverage | `#qa-engineer` |
+| Requirements, user stories, or acceptance criteria | `#product-manager` |
+
+**Implementation rules:**
+- Make only the changes required to resolve the issue.
+- Do not refactor unrelated code or add unrequested features.
+- If modifying any source file that feeds a composed output, edit the source and regenerate.
 
 **Step 5 — Run local validation**
 
@@ -257,11 +296,10 @@ When Dependabot opens a PR, follow these steps without exception:
 
 ## Available prompts
 
-Prompts are invocable agent workflows. Invoke with `#<name>` in VS Code Copilot Chat (the filename
-without extension). **Use the correct prompt for every task — never implement, fix, scaffold, or
-review without invoking the relevant prompt first.**
+Full reference of all available prompts. Invocation rules are in **Step 4** (implementation and
+scaffold prompts) and **Step 5** (review prompts). Use this table as a quick reference.
 
-### Implementation
+### Implementation — invoke at Step 4 before writing any code
 
 | Invoke | When to use |
 | ------ | ----------- |
@@ -275,7 +313,7 @@ review without invoking the relevant prompt first.**
 | `#deploy` | Deploying a service — pre-deploy checks, health verification, rollback plan |
 | `#project-kickoff` | Bootstrapping a brand-new project from scratch |
 
-### Review — run these before opening every PR
+### Review — run at Step 5 before opening the PR
 
 | Invoke | When to use |
 | ------ | ----------- |
@@ -284,7 +322,7 @@ review without invoking the relevant prompt first.**
 | `#performance-audit` | PRs touching database queries, caching, or frontend bundles |
 | `#dependency-audit` | When adding, removing, or upgrading any dependency |
 
-### Scaffolds
+### Scaffolds — invoke at Step 4 when building a new system component
 
 | Invoke | When to use |
 | ------ | ----------- |
@@ -296,7 +334,7 @@ review without invoking the relevant prompt first.**
 | `#notifications` | Scaffolding email, webhook, or push notifications with retry and opt-out |
 | `#monorepo` | Scaffolding a multi-service monorepo layout with per-service CI |
 
-### Personas — invoke for a specialist review lens
+### Personas — invoke concurrently at Step 4 when the work touches their domain
 
 | Invoke | When to use |
 | ------ | ----------- |

--- a/instructions/base.md
+++ b/instructions/base.md
@@ -62,9 +62,11 @@ Run all of the following in order. Zero errors allowed — do not proceed with a
 1. **Lint** — run the stack linter. Zero warnings. (Commands in the **Stack validation** section below.)
 2. **Type-check** — run the stack type checker in strict mode. Zero errors.
 3. **Tests** — run the full test suite. All must pass.
-4. **Security** — scan your diff for secrets, unsanitised inputs, broken auth, or injection vectors.
-   Run `#security-audit` on any change touching auth, data access, or external inputs.
-   Run `#audit` on every PR before opening it.
+4. **Review prompts** — run before opening the PR. Zero exceptions.
+   - `#audit` — every PR without exception.
+   - `#security-audit` — any PR touching auth, data access, external inputs, or dependencies.
+   - `#dependency-audit` — any PR that adds, removes, or changes a dependency (lockfile, manifest, or version pin).
+   - `#performance-audit` — any PR touching database queries, caching, pagination, or frontend bundle output.
 5. **Pre-commit hooks** — run `pre-commit run --all-files` if `.pre-commit-config.yaml` exists.
 6. **Composed files** — if the repo has `validate-composed.sh`, run it and commit any regenerated
    files before pushing.

--- a/instructions/base.md
+++ b/instructions/base.md
@@ -51,9 +51,48 @@ git checkout -b <type>/<issue-number>-<short-slug>
 
 **Step 4 — Implement the change**
 
-- Make only the changes required to resolve the issue
-- Do not refactor unrelated code or add unrequested features
-- If modifying any source file that feeds a composed output, edit the source and regenerate
+Before writing any code, invoke the matching prompt for the task type. Do not start implementing
+without it.
+
+**Implementation prompts — invoke at the start of this step based on task type:**
+
+| Task | Invoke |
+| ---- | ------ |
+| Implementing a new feature | `#implement-feature` |
+| Fixing a bug | `#fix-bug` |
+| Writing or updating tests | `#write-tests` |
+| Refactoring existing code | `#refactor` |
+| Writing documentation | `#write-docs` |
+| Recording an architecture decision | `#create-adr` |
+| Deploying a service | `#deploy` |
+| Bootstrapping a new project | `#project-kickoff` |
+
+**Scaffold prompts — invoke at the start of this step when building a new system component:**
+
+| Building | Invoke |
+| -------- | ------ |
+| A new CRUD resource | `#crud-api` |
+| Authentication / authorisation | `#auth` |
+| A new database, ORM, or migrations | `#database` |
+| A new UI component | `#frontend` |
+| An async background worker | `#background-jobs` |
+| A notifications system | `#notifications` |
+| A multi-service monorepo | `#monorepo` |
+
+**Persona prompts — invoke concurrently when the work touches their domain:**
+
+| Domain | Invoke |
+| ------ | ------ |
+| System design, service decomposition, or ADR | `#architect` |
+| Architecture quality or long-term maintainability concerns | `#principal-engineer` |
+| CI/CD, infrastructure, containerisation, or deployment | `#devops-engineer` |
+| Test strategy, quality risks, or edge case coverage | `#qa-engineer` |
+| Requirements, user stories, or acceptance criteria | `#product-manager` |
+
+**Implementation rules:**
+- Make only the changes required to resolve the issue.
+- Do not refactor unrelated code or add unrequested features.
+- If modifying any source file that feeds a composed output, edit the source and regenerate.
 
 **Step 5 — Run local validation**
 
@@ -253,11 +292,10 @@ When Dependabot opens a PR, follow these steps without exception:
 
 ## Available prompts
 
-Prompts are invocable agent workflows. Invoke with `#<name>` in VS Code Copilot Chat (the filename
-without extension). **Use the correct prompt for every task — never implement, fix, scaffold, or
-review without invoking the relevant prompt first.**
+Full reference of all available prompts. Invocation rules are in **Step 4** (implementation and
+scaffold prompts) and **Step 5** (review prompts). Use this table as a quick reference.
 
-### Implementation
+### Implementation — invoke at Step 4 before writing any code
 
 | Invoke | When to use |
 | ------ | ----------- |
@@ -271,7 +309,7 @@ review without invoking the relevant prompt first.**
 | `#deploy` | Deploying a service — pre-deploy checks, health verification, rollback plan |
 | `#project-kickoff` | Bootstrapping a brand-new project from scratch |
 
-### Review — run these before opening every PR
+### Review — run at Step 5 before opening the PR
 
 | Invoke | When to use |
 | ------ | ----------- |
@@ -280,7 +318,7 @@ review without invoking the relevant prompt first.**
 | `#performance-audit` | PRs touching database queries, caching, or frontend bundles |
 | `#dependency-audit` | When adding, removing, or upgrading any dependency |
 
-### Scaffolds
+### Scaffolds — invoke at Step 4 when building a new system component
 
 | Invoke | When to use |
 | ------ | ----------- |
@@ -292,7 +330,7 @@ review without invoking the relevant prompt first.**
 | `#notifications` | Scaffolding email, webhook, or push notifications with retry and opt-out |
 | `#monorepo` | Scaffolding a multi-service monorepo layout with per-service CI |
 
-### Personas — invoke for a specialist review lens
+### Personas — invoke concurrently at Step 4 when the work touches their domain
 
 | Invoke | When to use |
 | ------ | ----------- |

--- a/instructions/base.md
+++ b/instructions/base.md
@@ -57,8 +57,16 @@ git checkout -b <type>/<issue-number>-<short-slug>
 
 **Step 5 — Run local validation**
 
-Run whatever validation the stack requires (linting, type-checking, tests) before committing.
-If the repo has a `validate-composed.sh` script, run it and fix any stale files.
+Run all of the following in order. Zero errors allowed — do not proceed with any failing check.
+
+1. **Lint** — run the stack linter. Zero warnings. (Commands in the **Stack validation** section below.)
+2. **Type-check** — run the stack type checker in strict mode. Zero errors.
+3. **Tests** — run the full test suite. All must pass.
+4. **Security** — scan your diff for secrets, unsanitised inputs, broken auth, or injection vectors.
+   For significant changes invoke the `#security-audit` prompt before opening the PR.
+5. **Pre-commit hooks** — run `pre-commit run --all-files` if `.pre-commit-config.yaml` exists.
+6. **Composed files** — if the repo has `validate-composed.sh`, run it and commit any regenerated
+   files before pushing.
 
 **Step 6 — Commit using Conventional Commits**
 
@@ -79,7 +87,13 @@ Closes #<issue-number>"
 git push origin <branch-name>
 gh pr create \
   --title "<type>(<scope>): <description>" \
-  --body "Closes #<issue-number>" \
+  --body "Closes #<issue-number>
+
+## Changes
+- <what changed and why it matters>
+
+## Why
+- <problem solved or requirement met>" \
   --assignee @me
 ```
 
@@ -138,14 +152,14 @@ If you skipped any step, stop immediately, undo your changes (`git checkout main
 
 ## Project board lifecycle
 
-Every issue moves through these statuses automatically via CI:
+All card transitions are **automated by `project-automation.yml`** — never move cards manually.
 
-| Status          | Trigger                                                                                                 |
+| Status          | Automated trigger                                                                                       |
 | --------------- | ------------------------------------------------------------------------------------------------------- |
-| **Todo**        | Issue created and added to the board                                                                    |
+| **Todo**        | Issue created (added to board automatically on `issues: opened`)                                        |
 | **In Progress** | Branch matching the issue number is pushed                                                              |
 | **In Review**   | PR is opened (owner is auto-assigned as reviewer)                                                       |
-| **Done**        | PR is approved → card moves to Done and squash auto-merge is armed; fires once all required checks pass |
+| **Done**        | PR is approved → squash auto-merge fires once all required checks pass                                 |
 
 ## Code review expectations
 
@@ -211,6 +225,20 @@ Every issue moves through these statuses automatically via CI:
 - Audit new dependencies before adding: check maintenance status, license, bundle size.
 - Prefer well-maintained, widely-used packages over obscure alternatives.
 - Remove unused dependencies promptly.
+
+## Dependabot PRs
+
+When Dependabot opens a PR, follow these steps without exception:
+
+1. Wait for all CI checks to pass.
+2. **Patch or minor bump + green CI** — merge immediately:
+   ```bash
+   gh pr merge <pr-number> --squash --delete-branch
+   ```
+3. **Major version bump** — read the package changelog, check for breaking changes, update affected
+   code and tests on a new branch (following Steps 1–9 of the pre-flight above), then merge.
+4. Never merge a Dependabot PR with failing CI.
+5. Never close a Dependabot PR without merging it unless the dependency is being intentionally removed.
 
 ## Error handling
 

--- a/instructions/base.md
+++ b/instructions/base.md
@@ -14,41 +14,93 @@ These are universal rules that apply to **every** repository regardless of langu
 - Do not leave dead code, commented-out code, or TODO comments without a linked issue.
 - Treat compiler/linter warnings as errors.
 
-## MANDATORY pre-flight — do this before touching any file
+## MANDATORY pre-flight — execute every step, every time, before touching any file
 
-> **STOP.** Do not create, edit, or delete any file until all four steps below are complete.
+> **STOP.** Do not create, edit, or delete any file until all nine steps below are complete.
 > This applies to every change, no matter how small or "obvious".
 
 **Step 1 — Verify main is up to date**
 
 ```bash
-git checkout main && git pull origin main
+git checkout main
+git pull origin main
 ```
 
 **Step 2 — Create a GitHub issue**
+
+- Title: `<type>(<scope>): <short description>` using Conventional Commits format
+- Body: describe the problem, proposed solution, and acceptance criteria
+- Assign to yourself
+- Record the issue number — you will need it for every subsequent step
 
 ```bash
 gh issue create --title "<type>(scope): short description" --body "Problem, solution, acceptance criteria" --assignee @me
 ```
 
-Record the issue number. You cannot proceed without it.
-
 **Step 3 — Create a branch linked to that issue**
 
-```bash
-git checkout -b <type>/<issue-number>-<short-slug>
-# e.g. feat/42-add-pr-description-workflow
-```
+Branch naming format: `<type>/<issue-number>-<short-slug>`
 
 Valid types: `feat` `fix` `docs` `style` `refactor` `perf` `test` `build` `ci` `chore` `hotfix`
 
-**Step 4 — Make ALL changes on that branch, then open a PR**
+Examples: `feat/42-add-oauth-flow`, `fix/99-null-crash-on-login`, `chore/35-mvp-hardening`
 
 ```bash
-gh pr create --title "<type>(scope): description" --body "Closes #<issue-number>"
+git checkout -b <type>/<issue-number>-<short-slug>
+```
+
+**Step 4 — Implement the change**
+
+- Make only the changes required to resolve the issue
+- Do not refactor unrelated code or add unrequested features
+- If modifying any source file that feeds a composed output, edit the source and regenerate
+
+**Step 5 — Run local validation**
+
+Run whatever validation the stack requires (linting, type-checking, tests) before committing.
+If the repo has a `validate-composed.sh` script, run it and fix any stale files.
+
+**Step 6 — Commit using Conventional Commits**
+
+```bash
+git add -A
+git commit -m "<type>(<scope>): <description>
+
+<body explaining what and why>
+
+Closes #<issue-number>"
+```
+
+> The subject line must be **≤ 100 characters** — `commitlint` enforces this in CI.
+
+**Step 7 — Push and open a Pull Request**
+
+```bash
+git push origin <branch-name>
+gh pr create \
+  --title "<type>(<scope>): <description>" \
+  --body "Closes #<issue-number>" \
+  --assignee @me
+```
+
+**Step 8 — Wait for all CI checks to pass**
+
+Do not merge until every required check is green. If any check fails, fix it on the branch and
+push again. Never bypass checks.
+
+**Step 9 — Merge via squash only**
+
+```bash
+gh pr merge <pr-number> --squash --delete-branch
 ```
 
 If you skipped any step, stop immediately, undo your changes (`git checkout main`), and restart from Step 1.
+
+**Non-negotiable rules:**
+- Never push directly to `main`
+- Never use `--force` on `main`
+- Never skip CI
+- Every change must trace to an issue number
 
 ## Branch strategy
 

--- a/instructions/base.md
+++ b/instructions/base.md
@@ -89,6 +89,10 @@ without it.
 | Test strategy, quality risks, or edge case coverage | `#qa-engineer` |
 | Requirements, user stories, or acceptance criteria | `#product-manager` |
 
+> **Agent mode:** `#prompt-name` is human chat syntax. When running as an agent, use `read_file`
+> on each prompt's file path instead. The complete path-to-file dispatch tables for Steps 4 and 5
+> are in `.github/prompts/implementation/governance.prompt.md`.
+
 **Implementation rules:**
 - Make only the changes required to resolve the issue.
 - Do not refactor unrelated code or add unrequested features.
@@ -106,6 +110,8 @@ Run all of the following in order. Zero errors allowed — do not proceed with a
    - `#security-audit` — any PR touching auth, data access, external inputs, or dependencies.
    - `#dependency-audit` — any PR that adds, removes, or changes a dependency (lockfile, manifest, or version pin).
    - `#performance-audit` — any PR touching database queries, caching, pagination, or frontend bundle output.
+   > **Agent mode:** Use `read_file` on the matching path from the Step 5 dispatch table in
+   > `.github/prompts/implementation/governance.prompt.md`.
 5. **Pre-commit hooks** — run `pre-commit run --all-files` if `.pre-commit-config.yaml` exists.
 6. **Composed files** — if the repo has `validate-composed.sh`, run it and commit any regenerated
    files before pushing.

--- a/instructions/base.md
+++ b/instructions/base.md
@@ -50,17 +50,6 @@ gh pr create --title "<type>(scope): description" --body "Closes #<issue-number>
 
 If you skipped any step, stop immediately, undo your changes (`git checkout main`), and restart from Step 1.
 
-## Agentic workflow
-
-Before making any code change, always execute these steps in order:
-
-1. **Create a GitHub issue** describing the problem or feature. Use `gh issue create` with a clear title and body.
-2. **Create a branch** from `main` following the naming format `<type>/<issue-number>-<short-slug>` (e.g. `feat/42-add-oauth-flow`). Use `git checkout -b`.
-3. **Make the changes** on that branch — never commit directly to `main`.
-4. **Open a PR** that references the issue with `Closes #N` in the body.
-
-Do not skip or defer any of these steps, even for small or "obvious" fixes.
-
 ## Branch strategy
 
 - **`main`** is the default, protected branch. All changes merge into `main` via pull request.

--- a/instructions/base.md
+++ b/instructions/base.md
@@ -63,7 +63,8 @@ Run all of the following in order. Zero errors allowed — do not proceed with a
 2. **Type-check** — run the stack type checker in strict mode. Zero errors.
 3. **Tests** — run the full test suite. All must pass.
 4. **Security** — scan your diff for secrets, unsanitised inputs, broken auth, or injection vectors.
-   For significant changes invoke the `#security-audit` prompt before opening the PR.
+   Run `#security-audit` on any change touching auth, data access, or external inputs.
+   Run `#audit` on every PR before opening it.
 5. **Pre-commit hooks** — run `pre-commit run --all-files` if `.pre-commit-config.yaml` exists.
 6. **Composed files** — if the repo has `validate-composed.sh`, run it and commit any regenerated
    files before pushing.
@@ -247,3 +248,67 @@ When Dependabot opens a PR, follow these steps without exception:
 - Log errors with sufficient context for debugging (timestamp, request ID, stack trace).
 - Return meaningful error messages to callers; do not expose internal details to end users.
 - No problems stated in the 'Problems' tab should be ignored. If a problem is not actionable, it should be suppressed with a comment explaining why. Otherwise, all problems should be addressed before merging.
+
+## Available prompts
+
+Prompts are invocable agent workflows. Invoke with `#<name>` in VS Code Copilot Chat (the filename
+without extension). **Use the correct prompt for every task — never implement, fix, scaffold, or
+review without invoking the relevant prompt first.**
+
+### Implementation
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#governance` | **Before any change** — the full pre-flight workflow (issue → branch → implement → validate → PR → merge) |
+| `#implement-feature` | Implementing a new feature end-to-end |
+| `#fix-bug` | Diagnosing and fixing a bug — reproduce first, then trace root cause |
+| `#write-tests` | Writing tests for existing code |
+| `#refactor` | Refactoring without changing observable behaviour |
+| `#write-docs` | Generating or updating README, API docs, ADRs, or changelogs |
+| `#create-adr` | Recording an architecture decision in `docs/decisions/` |
+| `#deploy` | Deploying a service — pre-deploy checks, health verification, rollback plan |
+| `#project-kickoff` | Bootstrapping a brand-new project from scratch |
+
+### Review — run these before opening every PR
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#audit` | **Every PR** — validate the branch diff against all project standards |
+| `#security-audit` | Every PR touching auth, data access, external inputs, or dependencies |
+| `#performance-audit` | PRs touching database queries, caching, or frontend bundles |
+| `#dependency-audit` | When adding, removing, or upgrading any dependency |
+
+### Scaffolds
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#crud-api` | Scaffolding a new CRUD resource (routes, models, validation, tests, migrations) |
+| `#auth` | Wiring authentication and authorisation into a project |
+| `#database` | Setting up a new database, ORM, migrations, and health checks |
+| `#frontend` | Scaffolding a new UI component (structure, a11y, state management, tests) |
+| `#background-jobs` | Scaffolding an async worker (queue, retry policy, dead-letter handling) |
+| `#notifications` | Scaffolding email, webhook, or push notifications with retry and opt-out |
+| `#monorepo` | Scaffolding a multi-service monorepo layout with per-service CI |
+
+### Personas — invoke for a specialist review lens
+
+| Invoke | When to use |
+| ------ | ----------- |
+| `#architect` | System design, service decomposition, ADR facilitation |
+| `#principal-engineer` | Architecture review, abstraction quality, long-term maintainability |
+| `#devops-engineer` | CI/CD, containerisation, IaC, secrets management, deployment reliability |
+| `#qa-engineer` | Test coverage, quality risks, edge cases, regression strategy |
+| `#product-manager` | PRDs, user stories, acceptance criteria, feature scoping |
+
+## Available skills
+
+Skills are specialised knowledge files. Load the relevant file at the start of any task in that
+domain — do not rely on general knowledge alone. Skills live in `.github/skills/`.
+
+| Load this file | When |
+| -------------- | ---- |
+| `.github/skills/test-generation.skill.md` | Writing any test suite |
+| `.github/skills/code-analysis.skill.md` | Performing a deep code review or analysis |
+| `.github/skills/api-design-review.skill.md` | Reviewing any PR that adds or changes API endpoints |
+| `.github/skills/performance-profiling.skill.md` | Investigating or auditing performance |
+| `.github/skills/data-migration.skill.md` | Working on any database schema migration or data backfill |

--- a/instructions/stacks/csharp.md
+++ b/instructions/stacks/csharp.md
@@ -66,6 +66,24 @@
 - Add dependency health checks (database, message broker, external APIs) so the health endpoint reflects true service readiness.
 - Use `Activity` and OpenTelemetry for distributed tracing in services that participate in a larger system.
 
+## Stack validation
+
+Run these commands in order at Step 5. All must pass with zero errors before committing.
+
+```bash
+# Format check — no unformatted files
+dotnet format --verify-no-changes
+
+# Build — zero errors and zero warnings
+dotnet build -warnaserror
+
+# Tests — all must pass
+dotnet test
+
+# Dependency audit — no known vulnerabilities
+dotnet list package --vulnerable
+```
+
 ## Testing
 
 - **Unit tests**: Use xUnit. Use FluentAssertions for readable assertions. Use `Fact` and `Theory` attributes.

--- a/instructions/stacks/python.md
+++ b/instructions/stacks/python.md
@@ -51,6 +51,27 @@
 
 - Validate all environment variables at application startup using `pydantic-settings`. Never read `os.environ` inline at call sites — fail fast on missing or malformed config.
 
+## Stack validation
+
+Run these commands in order at Step 5. All must pass with zero errors before committing.
+
+```bash
+# Lint — zero errors
+ruff check .
+
+# Format check — no unformatted files
+ruff format --check .
+
+# Type-check — zero errors (strict mode)
+mypy .
+
+# Tests — all must pass
+pytest
+
+# Dependency audit — no known vulnerabilities
+pip-audit
+```
+
 ## Testing
 
 - **Unit tests**: Use `pytest`. Mock external dependencies with `pytest-mock` or `unittest.mock`. Follow the Arrange-Act-Assert pattern.

--- a/instructions/stacks/typescript.md
+++ b/instructions/stacks/typescript.md
@@ -47,6 +47,26 @@
 - Pass a child logger with request-scoped context (request ID, user ID) through the call chain — use `logger.child({ requestId })` per request.
 - Log at appropriate levels. Never log PII, tokens, or full request/response bodies.
 
+## Stack validation
+
+Run these commands in order at Step 5. All must pass with zero errors before committing.
+
+```bash
+# Lint — zero ESLint errors or warnings
+npm run lint
+
+# Type-check — zero TypeScript errors (strict mode)
+npm run typecheck
+
+# Tests — all must pass
+npm test
+
+# Dependency audit — no high or critical vulnerabilities
+npm audit --audit-level=high
+```
+
+If the project uses `pnpm`, substitute `pnpm run lint`, `pnpm run typecheck`, `pnpm test`, `pnpm audit --audit-level=high`.
+
 ## Testing
 
 - **Unit tests**: Use **Vitest** for all new TypeScript projects. It has native TypeScript/ESM support (no `ts-jest` wrapper), a Jest-compatible API (`describe`/`it`/`expect`), and runs significantly faster. Use Jest only if a project is already committed to it — the migration cost is low, but don't migrate just to migrate.

--- a/scripts/compose.sh
+++ b/scripts/compose.sh
@@ -143,6 +143,12 @@ if [ "$TARGET" = "all" ]; then
     compose_stack "$stack"
     compose_mcp "$stack"
   done
+  # Re-compose any multi-stack files that already exist in composed/
+  for multi_file in "$COMPOSED_DIR"/*+*-copilot-instructions.md; do
+    [ -f "$multi_file" ] || continue
+    multi_name="$(basename "$multi_file" -copilot-instructions.md)"
+    compose_multi_stack "$multi_name"
+  done
   echo "Done."
 elif [[ "$TARGET" == *"+"* ]]; then
   echo "Composing multi-stack: $TARGET..."


### PR DESCRIPTION
Closes #76

## Summary

### Documentation completeness
- **New: Green-field Quick Start section** — stack selection table, \--create\ flag usage, and a 4-step post-setup checklist (branch protection, \project-context.md\, CI check, sync workflow)
- **New: Brown-field Quick Start section** — replaces the old single code block with a 4-step onboarding walkthrough including post-onboarding steps
- **Expanded: Keep standards in sync** — from 3 lines to a full section covering what gets updated, how to trigger manually, how to review the PR, and the stack-detection requirement

### Broken path fixes
- Fixed \.github/copilot-instructions.md\ and \README.md\ contributing section — both referenced \.github/prompts/governance.prompt.md\ which does not exist; correct path is \.github/prompts/implementation/governance.prompt.md\

### Determinism
- Removed the 'Agentic workflow' bullet-list section from \instructions/base.md\ — it duplicated the MANDATORY pre-flight section above it but used vague bullets instead of explicit bash commands, creating ambiguity about which was authoritative
- Replaced README Contributing inline steps with a single reference to \governance.prompt.md\ so the contributing section cannot drift from the actual prompt
- Regenerated all \composed/\ files to reflect the \ase.md\ change