### PR TITLE
chore(lint): increase yamllint line-length limit from 120 to 130

### DIFF
--- a/.github/prompts/review/audit.prompt.md
+++ b/.github/prompts/review/audit.prompt.md
@@ -62,7 +62,7 @@ Every `.yml` change **must** use the absolute latest action versions. Flag anyth
 
 **Shell:** All `.sh` blocks must start with `set -euo pipefail`. All variables must be quoted.
 
-**Line length:** All `.yml` files are linted with `yamllint` at max 120 characters per line. Flag any line exceeding 120 characters — break long shell lines with `\` continuations and extract long strings into variables.
+**Line length:** All `.yml` files are linted with `yamllint` at max 130 characters per line. Flag any line exceeding 130 characters — break long shell lines with `\` continuations and extract long strings into variables.
 
 ---
 

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,6 @@
 {
   "MD013": {
-    "line_length": 120,
+    "line_length": 130,
     "tables": false
   }
 }

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ pre-commit install
 ```
 
 After that, every `git commit` automatically lints staged `*.yml`/`*.yaml` files with yamllint
-(max 120 chars/line).
+(max 130 chars/line).
 
 > **Ad-hoc:** To lint all files without committing (e.g. before raising a PR):
 >


### PR DESCRIPTION
Closes #80

## Changes
- Raised \line_length\ in \.markdownlint.json\ from 120 to 130
- Updated \README.md\ to reference 130 chars/line
- Updated \udit.prompt.md\ checklist to flag lines exceeding 130

## Why
The 120-character cap was too restrictive for long GitHub Actions \un:\ blocks and expression strings, causing spurious lint failures.