### PR TITLE
fix(mcp): bump sequential-thinking to 2025.12.18

### DIFF
--- a/composed/csharp.mcp.json
+++ b/composed/csharp.mcp.json
@@ -21,7 +21,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@modelcontextprotocol/server-sequential-thinking@2025.5.2"
+        "@modelcontextprotocol/server-sequential-thinking@2025.12.18"
       ]
     }
   }

--- a/composed/python+typescript.mcp.json
+++ b/composed/python+typescript.mcp.json
@@ -21,7 +21,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@modelcontextprotocol/server-sequential-thinking@2025.5.2"
+        "@modelcontextprotocol/server-sequential-thinking@2025.12.18"
       ]
     },
     "python": {

--- a/composed/python.mcp.json
+++ b/composed/python.mcp.json
@@ -21,7 +21,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@modelcontextprotocol/server-sequential-thinking@2025.5.2"
+        "@modelcontextprotocol/server-sequential-thinking@2025.12.18"
       ]
     },
     "python": {

--- a/composed/typescript.mcp.json
+++ b/composed/typescript.mcp.json
@@ -21,7 +21,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@modelcontextprotocol/server-sequential-thinking@2025.5.2"
+        "@modelcontextprotocol/server-sequential-thinking@2025.12.18"
       ]
     },
     "playwright": {

--- a/mcp/base.mcp.json
+++ b/mcp/base.mcp.json
@@ -13,7 +13,7 @@
     },
     "sequential-thinking": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking@2025.5.2"]
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking@2025.12.18"]
     }
   }
 }


### PR DESCRIPTION
Closes #86

## Changes
- Bump \@modelcontextprotocol/server-sequential-thinking\ from \2025.5.2\ to \2025.12.18\ in \mcp/base.mcp.json\
- Regenerate all four \composed/*.mcp.json\ files to reflect the new version

## Why
Version \2025.5.2\ was never published to npm. VS Code failed with \ETARGET\ on every chat start and prompted the user to restart the MCP server. \2025.12.18\ is the current \dist-tags.latest\.