### PR TITLE
fix(code-review): downgrade sensitive-file check to non-blocking attention tier

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Evaluate PR diff and post structured tiered review
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -157,7 +157,8 @@ jobs:
               attention.push(
                 `**Security-sensitive file(s) modified — human review recommended:**\n` +
                 sensitiveFiles.map(f => `  - \`${f.filename}\``).join('\n') + '\n' +
-                `  > Changes to auth, token, payment, or credential code carry elevated risk. Please ensure a human reviewer has checked these files before merging.`
+                `  > Changes to auth, token, payment, or credential code carry elevated risk.` +
+                ` Please ensure a human reviewer has checked these files before merging.`
               );
             }
 

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -147,12 +147,17 @@ jobs:
               );
             }
 
-            // Security-sensitive paths changed
+            // -- ⚠️ Attention (non-blocking, but flagged for human review) --
+            const attention = [];
+
+            // Security-sensitive paths changed — informational only, not a blocker.
+            // A bot cannot determine whether auth/credential changes are improvements
+            // or risks; only a human reviewer can make that call.
             if (sensitiveFiles.length) {
-              critical.push(
-                `**Security-sensitive file(s) modified — human review required:**\n` +
+              attention.push(
+                `**Security-sensitive file(s) modified — human review recommended:**\n` +
                 sensitiveFiles.map(f => `  - \`${f.filename}\``).join('\n') + '\n' +
-                `  > Changes to auth, token, payment, or credential code carry elevated risk.`
+                `  > Changes to auth, token, payment, or credential code carry elevated risk. Please ensure a human reviewer has checked these files before merging.`
               );
             }
 
@@ -213,7 +218,7 @@ jobs:
             if (CC_RE.test(prTitle))          passing.push('PR title follows Conventional Commits');
             if (!foundSecrets.length)          passing.push('No hardcoded secret patterns detected');
             if (!piiFiles.length)              passing.push('No PII patterns detected in source code');
-            if (!sensitiveFiles.length)        passing.push('No security-sensitive files modified');
+            if (!sensitiveFiles.length)        passing.push('No security-sensitive paths detected');
             if (prBody.trim().length >= 20)    passing.push('PR description provided');
             if (!debugHits.length)             passing.push('No debug statements in changed lines');
             if (sourceFiles.length === 0 || testFiles.length > 0)
@@ -228,6 +233,7 @@ jobs:
             // Summary table
             body += `| Tier | Count |\n|------|-------|\n`;
             body += `| 🚨 Requires Action | ${critical.length} |\n`;
+            body += `| ⚠️ Attention | ${attention.length} |\n`;
             body += `| 💡 Suggestions | ${suggestions.length} |\n`;
             body += `| ✅ Passing | ${passing.length} |\n\n`;
 
@@ -235,6 +241,12 @@ jobs:
               body += `---\n\n### 🚨 Requires Action\n\n`;
               body += `> These items **must be addressed** before this PR can merge.\n\n`;
               critical.forEach((c, i) => { body += `${i + 1}. ${c}\n\n`; });
+            }
+
+            if (attention.length) {
+              body += `---\n\n### ⚠️ Attention\n\n`;
+              body += `> Non-blocking — requires a human reviewer to verify before merging.\n\n`;
+              attention.forEach((a, i) => { body += `${i + 1}. ${a}\n\n`; });
             }
 
             if (suggestions.length) {


### PR DESCRIPTION
Closes #90

## Changes
- Introduced a dedicated \ttention\ tier for security-sensitive file detection — renders as a clearly labelled non-blocking section in the review comment
- Removed sensitive-file check from \critical\ (which triggered \REQUEST_CHANGES\ and hard-blocked PRs)
- Added \⚠️ Attention\ row to the summary table
- Hardcoded secrets, PII, and bad PR titles still trigger \REQUEST_CHANGES\

## Why
A bot cannot determine whether auth/credential changes are security improvements or risks. Hard-blocking legitimate security work with \REQUEST_CHANGES\ was the wrong call — the finding should be visible and clearly flagged for human reviewers without machine-blocking the merge.