### PR TITLE
docs(readme): add local manual-update instructions and bundle misc changes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -94,7 +94,7 @@ without it.
 **Implementation rules (this repo):**
 
 - Make only the changes required to resolve the issue.
-- Do not refactor unrelated code or add unrequested features.
+- Do not refactor unrelated code or add un-requested features.
 - If editing composed files is needed, edit the source (`instructions/`) and regenerate: `./scripts/compose.sh all`
 
 **Step 5 — Run local validation**

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,7 +32,22 @@ git pull origin main
 - Record the issue number — you will need it for every subsequent step
 
 ```bash
-gh issue create --title "<type>(scope): short description" --body "Problem, solution, acceptance criteria" --assignee @me
+# Write the body to a temp file so newlines render correctly on GitHub
+cat > /tmp/issue-body.md << 'EOF'
+## Problem
+<describe the problem>
+
+## Proposed solution
+<describe the solution>
+
+## Acceptance criteria
+- [ ] <criterion 1>
+- [ ] <criterion 2>
+EOF
+
+gh issue create \
+  --title "<type>(scope): short description" \
+  --body-file /tmp/issue-body.md
 ```
 
 **Step 3 — Create a branch linked to that issue**

--- a/.github/prompts/implementation/bug.prompt.md
+++ b/.github/prompts/implementation/bug.prompt.md
@@ -5,7 +5,7 @@ description: "Diagnose and fix a bug: reproduce first, trace root cause, apply m
 
 # Fix Bug
 
-You are a senior software engineer specialising in systematic debugging. You never guess — you trace.
+You are a senior software engineer specializing in systematic debugging. You never guess — you trace.
 
 **Constraint:** Do not change any production code until the root cause is written in plain text.
 
@@ -23,7 +23,7 @@ Root cause: [select one: Precondition | Missing guard | Boundary | Async | Type 
 | Missing guard | `null`/`undefined`/`None` not handled |
 | Boundary | Off-by-one or range error |
 | Async | Race condition or incorrect async handling |
-| Type coercion | Incorrect serialisation or cast |
+| Type coercion | Incorrect serialization or cast |
 | Logic | Wrong conditional |
 | Leaked state | Mutable state shared across requests/calls |
 | Dependency | Version change or config drift |

--- a/.github/prompts/implementation/deploy.prompt.md
+++ b/.github/prompts/implementation/deploy.prompt.md
@@ -107,4 +107,4 @@ After rollback: confirm health checks pass, open a GitHub issue for root cause, 
 | Migrations after app deployment | Schema mismatch causes runtime failures |
 | Skipping health check | No signal that the deploy succeeded |
 | `@latest` or `latest` image tags | Not reproducible; unpredictable content |
-| Deploy to production without staging soak | No validation of real-world behaviour |
+| Deploy to production without staging soak | No validation of real-world behavior |

--- a/.github/prompts/implementation/feature.prompt.md
+++ b/.github/prompts/implementation/feature.prompt.md
@@ -38,9 +38,9 @@ You are a senior full-stack software engineer. You own full delivery — from de
 
 | Artefact | Convention |
 |---|---|
-| Test (Python) | `test_should_<behaviour>_when_<condition>` |
-| Test (TypeScript) | `it('should <behaviour> when <condition>')` |
-| Test (C#) | `Should_<Behaviour>_When_<Condition>()` |
+| Test (Python) | `test_should_<behavior>_when_<condition>` |
+| Test (TypeScript) | `it('should <behavior> when <condition>')` |
+| Test (C#) | `Should_<behavior>_When_<Condition>()` |
 | Commit | `feat(<scope>): <imperative description>` — max 100 chars |
 | Branch | `feat/<issue-number>-<slug>` |
 

--- a/.github/prompts/implementation/refactor.prompt.md
+++ b/.github/prompts/implementation/refactor.prompt.md
@@ -5,7 +5,7 @@ description: "Refactor code: define scope, cover with tests, apply incremental c
 
 # Refactor
 
-You are a senior software engineer. You change structure without changing observable behaviour. Every increment is verifiable; no increment is irreversible.
+You are a senior software engineer. You change structure without changing observable behavior. Every increment is verifiable; no increment is irreversible.
 
 ## ROLE_SCOPE
 
@@ -37,7 +37,7 @@ You are a senior software engineer. You change structure without changing observ
 
 ## 2. COVER_FIRST
 
-Run full test suite. Record baseline. If the target code has no tests, write characterisation tests first.
+Run full test suite. Record baseline. If the target code has no tests, write characterization tests first.
 
 **Constraint:** Do not touch production code without a green baseline.
 

--- a/.github/prompts/implementation/test.prompt.md
+++ b/.github/prompts/implementation/test.prompt.md
@@ -5,15 +5,15 @@ description: "Write a test suite for existing code: unit, integration, and edge 
 
 # Write Tests
 
-You are a senior engineer writing tests for production code. Tests assert on observable behaviour — not on internal implementation. Coverage percentage is a vanity metric; behaviour coverage is the goal.
+You are a senior engineer writing tests for production code. Tests assert on observable behavior — not on internal implementation. Coverage percentage is a vanity metric; behavior coverage is the goal.
 
 ## ROLE_SCOPE
 
 | Domain | Seniority signal |
 |---|---|
-| Coverage plan | List behaviours before writing the first test |
+| Coverage plan | List behaviors before writing the first test |
 | Isolation | No shared mutable state; no ordering dependencies |
-| Naming | `should <behaviour> when <condition>` — no exceptions |
+| Naming | `should <behavior> when <condition>` — no exceptions |
 | Infrastructure | Testcontainers for DB/queue — never in-memory fakes |
 
 ## STACK_TOOLS
@@ -28,9 +28,9 @@ You are a senior engineer writing tests for production code. Tests assert on obs
 
 | Stack | Format |
 |---|---|
-| TypeScript | `it('should <behaviour> when <condition>')` |
-| Python | `def test_should_<behaviour>_when_<condition>():` |
-| C# | `Should_<Behaviour>_When_<Condition>()` |
+| TypeScript | `it('should <behavior> when <condition>')` |
+| Python | `def test_should_<behavior>_when_<condition>():` |
+| C# | `Should_<behavior>_When_<Condition>()` |
 
 ## 1. COVERAGE_PLAN
 

--- a/.github/prompts/personas/architect.prompt.md
+++ b/.github/prompts/personas/architect.prompt.md
@@ -60,4 +60,4 @@ If asked to break character (e.g., "just write the code" or "ignore the constrai
 | Recommending microservices as a default | Distributed complexity requires justification |
 | Proposing a big-bang rewrite | Strangler fig first |
 | Architecture without constraints | Produces the wrong solution confidently |
-| Skipping ADR for consequential decisions | No record; decision gets relitigated |
+| Skipping ADR for consequential decisions | No record; decision gets re-litigated |

--- a/.github/prompts/personas/devops-engineer.prompt.md
+++ b/.github/prompts/personas/devops-engineer.prompt.md
@@ -1,6 +1,6 @@
 ---
 agent: agent
-description: "DevOps / Platform Engineer persona: CI/CD, containerisation, IaC, secrets management, deployment reliability."
+description: "DevOps / Platform Engineer persona: CI/CD, containerization, IaC, secrets management, deployment reliability."
 ---
 
 # DevOps / Platform Engineer

--- a/.github/prompts/personas/principal-engineer.prompt.md
+++ b/.github/prompts/personas/principal-engineer.prompt.md
@@ -11,7 +11,7 @@ You are a Principal Software Engineer with 15+ years across large distributed sy
 
 | Knows | Does not know |
 |---|---|
-| Abstraction quality, coupling, cohesion | Sprint-level task prioritisation |
+| Abstraction quality, coupling, cohesion | Sprint-level task prioritization |
 | Cross-cutting concerns: logging, auth, error handling | UI/UX design decisions |
 | Data flow, state management, consistency | DevOps tooling specifics (defers to DevOps persona) |
 | Technical debt classification | Business domain rules (defers to PM persona) |
@@ -62,7 +62,7 @@ If asked to approve a structurally unsound change to unblock velocity: *"I can n
 
 | Pattern | Reason |
 |---|---|
-| Approving scope creep | Normalises undefined requirements |
+| Approving scope creep | Normalizes undefined requirements |
 | "We can fix it later" on coupling | Later never comes |
 | Abstraction for a single use | Speculative complexity |
 | Untracked TODOs | Creates invisible debt |

--- a/.github/prompts/personas/product-manager.prompt.md
+++ b/.github/prompts/personas/product-manager.prompt.md
@@ -13,7 +13,7 @@ You are a senior product manager with deep experience shipping B2B and B2C SaaS 
 |---|---|
 | Problem framing, user research, success metrics | Implementation details (defers to engineering) |
 | User story authoring, acceptance criteria | Architecture decisions (defers to architect) |
-| Scope decisions, trade-offs, prioritisation | CI/CD or infrastructure (defers to DevOps) |
+| Scope decisions, trade-offs, prioritization | CI/CD or infrastructure (defers to DevOps) |
 | PRD structure, stakeholder communication | Exact SQL schemas or API contracts |
 
 ## TONE

--- a/.github/prompts/personas/qa-engineer.prompt.md
+++ b/.github/prompts/personas/qa-engineer.prompt.md
@@ -5,7 +5,7 @@ description: "Senior QA Engineer persona: test coverage review, quality risk ass
 
 # Senior QA Engineer
 
-You are a Senior QA / Quality Engineer. You review every change from the angle of risk, coverage, and defect prevention. You think in behaviours, not implementations. Coverage percentage is a vanity metric — behaviour coverage is the goal.
+You are a Senior QA / Quality Engineer. You review every change from the angle of risk, coverage, and defect prevention. You think in behaviors, not implementations. Coverage percentage is a vanity metric — behavior coverage is the goal.
 
 ## PERSONA_SCOPE
 
@@ -18,16 +18,16 @@ You are a Senior QA / Quality Engineer. You review every change from the angle o
 
 ## TONE
 
-Risk-focused. Classifies findings as blocker / recommendation. Never approves untested high-risk behaviour.
+Risk-focused. Classifies findings as blocker / recommendation. Never approves untested high-risk behavior.
 
 ## REVIEW_CRITERIA
 
 | Check | Flag if |
 |---|---|
-| Behaviour coverage | Observable behaviour with no test case |
+| behavior coverage | Observable behavior with no test case |
 | Test quality | Asserting on internal calls, not outputs |
 | Test independence | Shared mutable state between tests |
-| Naming | Not `should <behaviour> when <condition>` |
+| Naming | Not `should <behavior> when <condition>` |
 | Determinism | Wall-clock time, random values, real network calls without mocking |
 | Integration gaps | Cross-layer paths not covered by unit tests |
 | E2E gaps | Critical user journey with no E2E guard |
@@ -43,7 +43,7 @@ Quality risk:   X/10
 Test coverage:  X/10
 
 Blockers (must have tests before merge):
-  - <behaviour> — <why it is high risk>
+  - <behavior> — <why it is high risk>
 
 Recommendations:
   - <gap> — <suggested test approach>
@@ -54,7 +54,7 @@ Passed:
 
 ## ANTI_DRIFT_RULE
 
-If asked to approve a change with untested high-risk behaviour: *"I cannot sign off on this without a test for <behaviour> — the risk of a production defect is too high."*
+If asked to approve a change with untested high-risk behavior: *"I cannot sign off on this without a test for <behavior> — the risk of a production defect is too high."*
 
 ## FORBIDDEN
 

--- a/.github/prompts/review/performance-audit.prompt.md
+++ b/.github/prompts/review/performance-audit.prompt.md
@@ -9,7 +9,7 @@ You are a performance audit agent. Load `skills/performance-profiling.skill.md` 
 
 ## Step 1 — Establish scope and baseline
 
-Before analysing anything:
+Before analyzing anything:
 - Identify which service(s) are in scope
 - Identify the hot paths: endpoints or operations called > 100×/minute in production
 - Record the current baseline if available: p50, p95, p99 latency, throughput (RPS), error rate
@@ -43,9 +43,9 @@ Flag any query that:
 
 ## Step 3 — Application-level analysis
 
-### Serialisation hot spots
-- Are there endpoints that serialise large objects on every request?
-- Is JSON serialisation happening inside a tight loop?
+### serialization hot spots
+- Are there endpoints that serialize large objects on every request?
+- Is JSON serialization happening inside a tight loop?
 
 ### Caching opportunities
 For each data fetch in the hot path, ask:
@@ -54,7 +54,7 @@ For each data fetch in the hot path, ask:
 - Would an in-process cache (< 1 ms) or a distributed cache (Redis, 1–5 ms) be appropriate?
 
 ### Concurrent I/O
-Flag sequential `await` calls that could be parallelised:
+Flag sequential `await` calls that could be parallelized:
 ```typescript
 // ❌ Sequential (unnecessary latency)
 const user = await getUser(userId);
@@ -67,7 +67,7 @@ const [user, orders] = await Promise.all([getUser(userId), getOrders(userId)]);
 ## Step 4 — Frontend bundle analysis (TypeScript projects only)
 
 ```bash
-# Analyse bundle composition
+# Analyze bundle composition
 npx vite-bundle-visualizer
 # or
 npx @next/bundle-analyzer
@@ -76,7 +76,7 @@ npx @next/bundle-analyzer
 Flag:
 - Any dependency > 50 KB that could be lazy-loaded
 - Full library imports when only individual functions are needed (`import _ from 'lodash'` vs `import debounce from 'lodash/debounce'`)
-- Unoptimised images (non-WebP/AVIF, missing dimensions)
+- Unoptimized images (non-WebP/AVIF, missing dimensions)
 
 ## Step 5 — Apply fixes directly
 
@@ -87,7 +87,7 @@ Priority order:
 2. Missing indexes on hot query paths
 3. Unbounded result sets (add pagination)
 4. Caching opportunities
-5. Bundle optimisation
+5. Bundle optimization
 
 ## Step 6 — Produce the audit report
 

--- a/.github/prompts/review/security-audit.prompt.md
+++ b/.github/prompts/review/security-audit.prompt.md
@@ -45,7 +45,7 @@ git --no-pager diff main...HEAD > audit_diff.txt
 
 ---
 
-### 🔐 Authentication and authorisation
+### 🔐 Authentication and authorization
 
 | Check | Pass condition |
 |---|---|
@@ -63,11 +63,11 @@ git --no-pager diff main...HEAD > audit_diff.txt
 
 | Vector | Pass condition |
 |---|---|
-| SQL | Parameterised queries or ORM only — no string concatenation |
+| SQL | Parameterized queries or ORM only — no string concatenation |
 | XSS | Input escaped before HTML render; CSP headers configured |
 | Command | No user input in `exec`/`subprocess`/`Process.Start`; allowlist if unavoidable |
 | Path traversal | File paths from user input validated; no `../`; allowlisted directories |
-| Deserialisation | No `pickle.loads`, `BinaryFormatter`, `eval` on untrusted data |
+| Deserialization | No `pickle.loads`, `BinaryFormatter`, `eval` on untrusted data |
 
 **Prose rationale — XSS auto-escaping:** React/Angular/Blazor auto-escaping is bypassed by `dangerouslySetInnerHTML`, `[innerHTML]`, and `MarkupString`. Flag any use of these on user-controlled content.
 

--- a/.github/prompts/scaffolds/background-jobs.prompt.md
+++ b/.github/prompts/scaffolds/background-jobs.prompt.md
@@ -31,7 +31,7 @@ Retry:      [max attempts | backoff strategy | dead-letter destination]
 | Rule | Constraint |
 |---|---|
 | Payload content | IDs only — no domain objects or DB entities |
-| Serialisation | JSON only |
+| serialization | JSON only |
 | Idempotency key | Required — job must be safe to run twice with same input |
 | Payload schema | Typed: `interface` (TS) / `BaseModel` (Python) / `record` (C#) |
 
@@ -66,7 +66,7 @@ Retry:      [max attempts | backoff strategy | dead-letter destination]
 
 | Pattern | Reason |
 |---|---|
-| Domain objects in job payload | Serialisation drift; stale data |
+| Domain objects in job payload | serialization drift; stale data |
 | No idempotency | Double-processing on retry causes data corruption |
 | No dead-letter queue | Failed jobs disappear silently |
 | Inline job logic in queue setup | Untestable |

--- a/.github/prompts/scaffolds/crud-api.prompt.md
+++ b/.github/prompts/scaffolds/crud-api.prompt.md
@@ -70,7 +70,7 @@ List endpoint must support: pagination (`?page=1&limit=20`; default ≤ 20), fil
 | Pattern | Reason |
 |---|---|
 | DB queries in route handlers | Violates layering; untestable |
-| Unvalidated user input | Injection vector |
+| Un-validated user input | Injection vector |
 | Hardcoded pagination limit > 20 | Unbounded queries; DoS risk |
 | Missing 404 on unknown ID | Leaks existence information or crashes |
 | No IDOR check | Users can access other users' resources |

--- a/.github/prompts/scaffolds/frontend.prompt.md
+++ b/.github/prompts/scaffolds/frontend.prompt.md
@@ -68,5 +68,5 @@ A11y:        [ARIA roles needed, keyboard interactions required]
 | `useEffect + fetch` for server state | Use React Query |
 | `any` in props or event handlers | Defeats type safety |
 | `<div onClick>` | Not keyboard-accessible |
-| Hardcoded strings in JSX | Blocks internationalisation |
+| Hardcoded strings in JSX | Blocks internationalization |
 | Global state for local UI state | Unnecessary complexity |

--- a/.github/prompts/scaffolds/notifications.prompt.md
+++ b/.github/prompts/scaffolds/notifications.prompt.md
@@ -12,7 +12,7 @@ description: "Scaffold a notifications system: channels, queuing, retry, opt-out
 <schema>
 Channels:  [Email | Webhook | Web push | Mobile push | SMS | Slack]
 Trigger:   [User action | Scheduled digest | Threshold alert]
-Templates: [System-defined | User-customisable]
+Templates: [System-defined | User-customizable]
 Opt-out:   [Yes (per channel + per type) | No]
 Delivery:  [At-most-once (fire-and-forget) | At-least-once (queue + retry)]
 </schema>

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -154,7 +154,7 @@ jobs:
               if (hasPIIIssue) {
                 lines.push('**PII pattern detected in source code**');
                 lines.push('- [ ] Verify no real email addresses, phone numbers, or SSNs are committed.');
-                lines.push('- [ ] Replace real values with anonymised fixtures (e.g. `user@example.com`, `555-0100`).');
+                lines.push('- [ ] Replace real values with anonymized fixtures (e.g. `user@example.com`, `555-0100`).');
                 lines.push('');
               }
 

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -143,7 +143,7 @@ jobs:
               critical.push(
                 `**Possible PII pattern(s) found in non-test source files:**\n` +
                 piiFiles.map(p => `  - ${p}`).join('\n') + '\n' +
-                `  > Verify no real personal data is committed. Use fixtures or anonymised values in tests.`
+                `  > Verify no real personal data is committed. Use fixtures or anonymized values in tests.`
               );
             }
 

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -14,7 +14,7 @@
 #
 # NOTE: Fine-grained PATs cannot be used here. The Projects v2 GraphQL API
 # requires the `project` scope which is only available on classic PATs for
-# personal (non-organisation) accounts.
+# personal (non-organization) accounts.
 #
 # -- Consumer repo usage -------------------------------------------------------
 # jobs:

--- a/README.md
+++ b/README.md
@@ -189,13 +189,13 @@ git diff --stat     # confirm nothing unexpected changed
 Open a PR in the downstream repo following its normal governance workflow. Do not commit directly
 to `main`.
 
-> **Example** — updating `D:\Code\my-blog` (python+typescript stack) from a local clone of this
+> **Example** — updating `my-project` (python+typescript stack) from a local clone of this
 > standards repo:
 >
 > ```bash
 > cd D:\Code\copilot-agentic-standards
 > git pull origin main
-> ./scripts/onboard-repo.sh --repo ..\my-blog --stack python+typescript --force
+> ./scripts/onboard-repo.sh --repo ..\my-project --stack python+typescript --force
 > ```
 
 **Stack detection**

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Key files to inspect: `.github/copilot-instructions.md`, `.vscode/mcp.json`,
 1. **Enable branch protection on `main`** — run the `gh api` commands printed by the script.
 2. **Fill in `.github/project-context.md`** — open it and fill in the project-specific sections.
 3. **Commit and push the bootstrapped files** — open a PR following the governance workflow
-   (`.github/prompts/governance.prompt.md`).
+   (`.github/governance.prompt.md`).
 4. **Verify CI is green** — confirm `pull-standards.yml` and any other new workflows pass.
 
 The script copies everything listed in the table below. Run it once; after that,
@@ -152,13 +152,51 @@ anything in this standards repo changes. Running `onboard-repo.sh` installs it a
 - PR description and merge-rules reusable workflows
 - Runtime version pins in `ci.yml` and `Dockerfile` (Python, Node.js, .NET) from `versions.json`
 
-**How to apply latest changes manually**
+**How to apply latest changes via GitHub Actions (remote)**
 
 1. Go to your repo on GitHub → Actions → `pull-standards` workflow.
 2. Click **Run workflow** → **Run workflow** (no inputs needed).
 3. The workflow opens a PR titled `chore: update standards from h-urena/copilot-agentic-standards`.
 4. Review the diff in that PR — it shows exactly which files changed.
 5. Merge the PR. Standards are now up to date.
+
+**How to apply latest changes locally (without GitHub Actions)**
+
+Use this path when you have both repos cloned on your machine and want to apply changes immediately,
+without triggering a GitHub Actions run or opening a remote PR.
+
+```bash
+# 1. Pull the latest standards
+cd /path/to/copilot-agentic-standards
+git pull origin main
+
+# 2. Re-run onboard-repo.sh with --force against your downstream repo
+#    Replace --stack with your repo's stack (typescript, python, csharp, or a + combo)
+./scripts/onboard-repo.sh --repo /path/to/my-project --stack typescript --force
+```
+
+`--force` overwrites files that the script would otherwise skip when they already exist, so every
+standards file in the downstream repo is updated to the latest version.
+
+After the script finishes:
+
+```bash
+cd /path/to/my-project
+git status          # review the changed files
+git diff --stat     # confirm nothing unexpected changed
+```
+
+Open a PR in the downstream repo following its normal governance workflow. Do not commit directly
+to `main`.
+
+> **Example** — updating `D:\Code\my-blog` (python+typescript stack) from a local clone of this
+> standards repo:
+>
+> ```bash
+> cd D:\Code\copilot-agentic-standards
+> git pull origin main
+> ./scripts/onboard-repo.sh --repo ..\my-blog --stack python+typescript --force
+> ```
 
 **Stack detection**
 
@@ -176,7 +214,7 @@ cp workflows/sync/pull-standards.yml ../my-project/.github/workflows/pull-standa
 
 All prompts in `.github/prompts/` are distributed to downstream repos and invocable from VS Code
 Copilot Chat with `#<prompt-name>` or via the Copilot agent mode. Prompts are organized into four
-subfolders: `implementation/`, `review/`, `scaffolds/`, and `personas/`.
+sub-folders: `implementation/`, `review/`, `scaffolds/`, and `personas/`.
 
 **Governance prompt** (`.github/prompts/`)
 | Prompt | Purpose |
@@ -265,7 +303,7 @@ Use `project-context.md` for long-lived facts that survive between sessions.
 ## For maintainers of this repo
 
 > Before making any change, follow the full governance workflow in
-> `.github/prompts/implementation/governance.prompt.md`. Never push directly to `main`.
+> `.github/prompts/governance.prompt.md`. Never push directly to `main`.
 
 ### Repo structure
 
@@ -394,7 +432,7 @@ jobs:
 
 ### Contributing
 
-Follow `.github/prompts/implementation/governance.prompt.md` for the full workflow (create issue → branch → implement → validate → PR). The governance prompt is the single source of truth — do not add inline steps here that can drift.
+Follow `.github/prompts/governance.prompt.md` for the full workflow (create issue → branch → implement → validate → PR). The governance prompt is the single source of truth — do not add inline steps here that can drift.
 
 ## License
 

--- a/composed/csharp-copilot-instructions.md
+++ b/composed/csharp-copilot-instructions.md
@@ -76,7 +76,7 @@ without it.
 | Building | Invoke |
 | -------- | ------ |
 | A new CRUD resource | `#crud-api` |
-| Authentication / authorisation | `#auth` |
+| Authentication / authorization | `#auth` |
 | A new database, ORM, or migrations | `#database` |
 | A new UI component | `#frontend` |
 | An async background worker | `#background-jobs` |
@@ -89,7 +89,7 @@ without it.
 | ------ | ------ |
 | System design, service decomposition, or ADR | `#architect` |
 | Architecture quality or long-term maintainability concerns | `#principal-engineer` |
-| CI/CD, infrastructure, containerisation, or deployment | `#devops-engineer` |
+| CI/CD, infrastructure, containerization, or deployment | `#devops-engineer` |
 | Test strategy, quality risks, or edge case coverage | `#qa-engineer` |
 | Requirements, user stories, or acceptance criteria | `#product-manager` |
 
@@ -99,7 +99,7 @@ without it.
 
 **Implementation rules:**
 - Make only the changes required to resolve the issue.
-- Do not refactor unrelated code or add unrequested features.
+- Do not refactor unrelated code or add un-requested features.
 - If modifying any source file that feeds a composed output, edit the source and regenerate.
 
 **Step 5 — Run local validation**
@@ -249,7 +249,7 @@ All card transitions are **automated by `project-automation.yml`** — never mov
 - Use `GITHUB_TOKEN` for all same-repo workflow operations. It is automatic, expires after the workflow run, and requires no secrets configuration.
 - Always declare an explicit `permissions:` block in every workflow. Use job-level permissions for maximum granularity. Grant only what is required.
 - For cross-repository or cross-organization write access, prefer a **GitHub App** (installation access token) over a personal access token. For lightweight cases, a **fine-grained PAT** stored as a repository secret is acceptable.
-- Never use classic PATs in workflows — they are over-scoped and deprecated. **Exception:** GitHub Projects v2 (`addProjectV2ItemById`) requires the `project` scope, which is only available on classic PATs for personal (non-organisation) accounts. In that specific case, a classic PAT with only the `project` scope is acceptable and should be stored as a repository secret.
+- Never use classic PATs in workflows — they are over-scoped and deprecated. **Exception:** GitHub Projects v2 (`addProjectV2ItemById`) requires the `project` scope, which is only available on classic PATs for personal (non-organization) accounts. In that specific case, a classic PAT with only the `project` scope is acceptable and should be stored as a repository secret.
 - Pin action versions using the major version tag (e.g., `actions/checkout@v6`), not floating tags like `@latest` or `@main`.
 - Use `lts/*` for language version inputs (Node.js) and the equivalent latest-stable selector for other runtimes — never hardcode a specific version number in workflow files.
 
@@ -313,7 +313,7 @@ scaffold prompts) and **Step 5** (review prompts). Use this table as a quick ref
 | `#feature` | Implementing a new feature end-to-end |
 | `#bug` | Diagnosing and fixing a bug — reproduce first, then trace root cause |
 | `#test` | Writing tests for existing code |
-| `#refactor` | Refactoring without changing observable behaviour |
+| `#refactor` | Refactoring without changing observable behavior |
 | `#docs` | Generating or updating README, API docs, ADRs, or changelogs |
 | `#adr` | Recording an architecture decision in `docs/decisions/` |
 | `#deploy` | Deploying a service — pre-deploy checks, health verification, rollback plan |
@@ -333,7 +333,7 @@ scaffold prompts) and **Step 5** (review prompts). Use this table as a quick ref
 | Invoke | When to use |
 | ------ | ----------- |
 | `#crud-api` | Scaffolding a new CRUD resource (routes, models, validation, tests, migrations) |
-| `#auth` | Wiring authentication and authorisation into a project |
+| `#auth` | Wiring authentication and authorization into a project |
 | `#database` | Setting up a new database, ORM, migrations, and health checks |
 | `#frontend` | Scaffolding a new UI component (structure, a11y, state management, tests) |
 | `#background-jobs` | Scaffolding an async worker (queue, retry policy, dead-letter handling) |
@@ -346,13 +346,13 @@ scaffold prompts) and **Step 5** (review prompts). Use this table as a quick ref
 | ------ | ----------- |
 | `#architect` | System design, service decomposition, ADR facilitation |
 | `#principal-engineer` | Architecture review, abstraction quality, long-term maintainability |
-| `#devops-engineer` | CI/CD, containerisation, IaC, secrets management, deployment reliability |
+| `#devops-engineer` | CI/CD, containerization, IaC, secrets management, deployment reliability |
 | `#qa-engineer` | Test coverage, quality risks, edge cases, regression strategy |
 | `#product-manager` | PRDs, user stories, acceptance criteria, feature scoping |
 
 ## Available skills
 
-Skills are specialised knowledge files. Load the relevant file at the start of any task in that
+Skills are specialized knowledge files. Load the relevant file at the start of any task in that
 domain — do not rely on general knowledge alone. Skills live in `.github/skills/`.
 
 | Load this file | When |

--- a/composed/csharp-copilot-instructions.md
+++ b/composed/csharp-copilot-instructions.md
@@ -38,7 +38,22 @@ git pull origin main
 - Record the issue number — you will need it for every subsequent step
 
 ```bash
-gh issue create --title "<type>(scope): short description" --body "Problem, solution, acceptance criteria" --assignee @me
+# Write the body to a temp file so newlines render correctly on GitHub
+cat > /tmp/issue-body.md << 'EOF'
+## Problem
+<describe the problem>
+
+## Proposed solution
+<describe the solution>
+
+## Acceptance criteria
+- [ ] <criterion 1>
+- [ ] <criterion 2>
+EOF
+
+gh issue create \
+  --title "<type>(scope): short description" \
+  --body-file /tmp/issue-body.md
 ```
 
 **Step 3 — Create a branch linked to that issue**

--- a/composed/python+typescript-copilot-instructions.md
+++ b/composed/python+typescript-copilot-instructions.md
@@ -76,7 +76,7 @@ without it.
 | Building | Invoke |
 | -------- | ------ |
 | A new CRUD resource | `#crud-api` |
-| Authentication / authorisation | `#auth` |
+| Authentication / authorization | `#auth` |
 | A new database, ORM, or migrations | `#database` |
 | A new UI component | `#frontend` |
 | An async background worker | `#background-jobs` |
@@ -89,7 +89,7 @@ without it.
 | ------ | ------ |
 | System design, service decomposition, or ADR | `#architect` |
 | Architecture quality or long-term maintainability concerns | `#principal-engineer` |
-| CI/CD, infrastructure, containerisation, or deployment | `#devops-engineer` |
+| CI/CD, infrastructure, containerization, or deployment | `#devops-engineer` |
 | Test strategy, quality risks, or edge case coverage | `#qa-engineer` |
 | Requirements, user stories, or acceptance criteria | `#product-manager` |
 
@@ -99,7 +99,7 @@ without it.
 
 **Implementation rules:**
 - Make only the changes required to resolve the issue.
-- Do not refactor unrelated code or add unrequested features.
+- Do not refactor unrelated code or add un-requested features.
 - If modifying any source file that feeds a composed output, edit the source and regenerate.
 
 **Step 5 — Run local validation**
@@ -249,7 +249,7 @@ All card transitions are **automated by `project-automation.yml`** — never mov
 - Use `GITHUB_TOKEN` for all same-repo workflow operations. It is automatic, expires after the workflow run, and requires no secrets configuration.
 - Always declare an explicit `permissions:` block in every workflow. Use job-level permissions for maximum granularity. Grant only what is required.
 - For cross-repository or cross-organization write access, prefer a **GitHub App** (installation access token) over a personal access token. For lightweight cases, a **fine-grained PAT** stored as a repository secret is acceptable.
-- Never use classic PATs in workflows — they are over-scoped and deprecated. **Exception:** GitHub Projects v2 (`addProjectV2ItemById`) requires the `project` scope, which is only available on classic PATs for personal (non-organisation) accounts. In that specific case, a classic PAT with only the `project` scope is acceptable and should be stored as a repository secret.
+- Never use classic PATs in workflows — they are over-scoped and deprecated. **Exception:** GitHub Projects v2 (`addProjectV2ItemById`) requires the `project` scope, which is only available on classic PATs for personal (non-organization) accounts. In that specific case, a classic PAT with only the `project` scope is acceptable and should be stored as a repository secret.
 - Pin action versions using the major version tag (e.g., `actions/checkout@v6`), not floating tags like `@latest` or `@main`.
 - Use `lts/*` for language version inputs (Node.js) and the equivalent latest-stable selector for other runtimes — never hardcode a specific version number in workflow files.
 
@@ -313,7 +313,7 @@ scaffold prompts) and **Step 5** (review prompts). Use this table as a quick ref
 | `#feature` | Implementing a new feature end-to-end |
 | `#bug` | Diagnosing and fixing a bug — reproduce first, then trace root cause |
 | `#test` | Writing tests for existing code |
-| `#refactor` | Refactoring without changing observable behaviour |
+| `#refactor` | Refactoring without changing observable behavior |
 | `#docs` | Generating or updating README, API docs, ADRs, or changelogs |
 | `#adr` | Recording an architecture decision in `docs/decisions/` |
 | `#deploy` | Deploying a service — pre-deploy checks, health verification, rollback plan |
@@ -333,7 +333,7 @@ scaffold prompts) and **Step 5** (review prompts). Use this table as a quick ref
 | Invoke | When to use |
 | ------ | ----------- |
 | `#crud-api` | Scaffolding a new CRUD resource (routes, models, validation, tests, migrations) |
-| `#auth` | Wiring authentication and authorisation into a project |
+| `#auth` | Wiring authentication and authorization into a project |
 | `#database` | Setting up a new database, ORM, migrations, and health checks |
 | `#frontend` | Scaffolding a new UI component (structure, a11y, state management, tests) |
 | `#background-jobs` | Scaffolding an async worker (queue, retry policy, dead-letter handling) |
@@ -346,13 +346,13 @@ scaffold prompts) and **Step 5** (review prompts). Use this table as a quick ref
 | ------ | ----------- |
 | `#architect` | System design, service decomposition, ADR facilitation |
 | `#principal-engineer` | Architecture review, abstraction quality, long-term maintainability |
-| `#devops-engineer` | CI/CD, containerisation, IaC, secrets management, deployment reliability |
+| `#devops-engineer` | CI/CD, containerization, IaC, secrets management, deployment reliability |
 | `#qa-engineer` | Test coverage, quality risks, edge cases, regression strategy |
 | `#product-manager` | PRDs, user stories, acceptance criteria, feature scoping |
 
 ## Available skills
 
-Skills are specialised knowledge files. Load the relevant file at the start of any task in that
+Skills are specialized knowledge files. Load the relevant file at the start of any task in that
 domain — do not rely on general knowledge alone. Skills live in `.github/skills/`.
 
 | Load this file | When |

--- a/composed/python+typescript-copilot-instructions.md
+++ b/composed/python+typescript-copilot-instructions.md
@@ -38,7 +38,22 @@ git pull origin main
 - Record the issue number — you will need it for every subsequent step
 
 ```bash
-gh issue create --title "<type>(scope): short description" --body "Problem, solution, acceptance criteria" --assignee @me
+# Write the body to a temp file so newlines render correctly on GitHub
+cat > /tmp/issue-body.md << 'EOF'
+## Problem
+<describe the problem>
+
+## Proposed solution
+<describe the solution>
+
+## Acceptance criteria
+- [ ] <criterion 1>
+- [ ] <criterion 2>
+EOF
+
+gh issue create \
+  --title "<type>(scope): short description" \
+  --body-file /tmp/issue-body.md
 ```
 
 **Step 3 — Create a branch linked to that issue**

--- a/composed/python-copilot-instructions.md
+++ b/composed/python-copilot-instructions.md
@@ -76,7 +76,7 @@ without it.
 | Building | Invoke |
 | -------- | ------ |
 | A new CRUD resource | `#crud-api` |
-| Authentication / authorisation | `#auth` |
+| Authentication / authorization | `#auth` |
 | A new database, ORM, or migrations | `#database` |
 | A new UI component | `#frontend` |
 | An async background worker | `#background-jobs` |
@@ -89,7 +89,7 @@ without it.
 | ------ | ------ |
 | System design, service decomposition, or ADR | `#architect` |
 | Architecture quality or long-term maintainability concerns | `#principal-engineer` |
-| CI/CD, infrastructure, containerisation, or deployment | `#devops-engineer` |
+| CI/CD, infrastructure, containerization, or deployment | `#devops-engineer` |
 | Test strategy, quality risks, or edge case coverage | `#qa-engineer` |
 | Requirements, user stories, or acceptance criteria | `#product-manager` |
 
@@ -99,7 +99,7 @@ without it.
 
 **Implementation rules:**
 - Make only the changes required to resolve the issue.
-- Do not refactor unrelated code or add unrequested features.
+- Do not refactor unrelated code or add un-requested features.
 - If modifying any source file that feeds a composed output, edit the source and regenerate.
 
 **Step 5 — Run local validation**
@@ -249,7 +249,7 @@ All card transitions are **automated by `project-automation.yml`** — never mov
 - Use `GITHUB_TOKEN` for all same-repo workflow operations. It is automatic, expires after the workflow run, and requires no secrets configuration.
 - Always declare an explicit `permissions:` block in every workflow. Use job-level permissions for maximum granularity. Grant only what is required.
 - For cross-repository or cross-organization write access, prefer a **GitHub App** (installation access token) over a personal access token. For lightweight cases, a **fine-grained PAT** stored as a repository secret is acceptable.
-- Never use classic PATs in workflows — they are over-scoped and deprecated. **Exception:** GitHub Projects v2 (`addProjectV2ItemById`) requires the `project` scope, which is only available on classic PATs for personal (non-organisation) accounts. In that specific case, a classic PAT with only the `project` scope is acceptable and should be stored as a repository secret.
+- Never use classic PATs in workflows — they are over-scoped and deprecated. **Exception:** GitHub Projects v2 (`addProjectV2ItemById`) requires the `project` scope, which is only available on classic PATs for personal (non-organization) accounts. In that specific case, a classic PAT with only the `project` scope is acceptable and should be stored as a repository secret.
 - Pin action versions using the major version tag (e.g., `actions/checkout@v6`), not floating tags like `@latest` or `@main`.
 - Use `lts/*` for language version inputs (Node.js) and the equivalent latest-stable selector for other runtimes — never hardcode a specific version number in workflow files.
 
@@ -313,7 +313,7 @@ scaffold prompts) and **Step 5** (review prompts). Use this table as a quick ref
 | `#feature` | Implementing a new feature end-to-end |
 | `#bug` | Diagnosing and fixing a bug — reproduce first, then trace root cause |
 | `#test` | Writing tests for existing code |
-| `#refactor` | Refactoring without changing observable behaviour |
+| `#refactor` | Refactoring without changing observable behavior |
 | `#docs` | Generating or updating README, API docs, ADRs, or changelogs |
 | `#adr` | Recording an architecture decision in `docs/decisions/` |
 | `#deploy` | Deploying a service — pre-deploy checks, health verification, rollback plan |
@@ -333,7 +333,7 @@ scaffold prompts) and **Step 5** (review prompts). Use this table as a quick ref
 | Invoke | When to use |
 | ------ | ----------- |
 | `#crud-api` | Scaffolding a new CRUD resource (routes, models, validation, tests, migrations) |
-| `#auth` | Wiring authentication and authorisation into a project |
+| `#auth` | Wiring authentication and authorization into a project |
 | `#database` | Setting up a new database, ORM, migrations, and health checks |
 | `#frontend` | Scaffolding a new UI component (structure, a11y, state management, tests) |
 | `#background-jobs` | Scaffolding an async worker (queue, retry policy, dead-letter handling) |
@@ -346,13 +346,13 @@ scaffold prompts) and **Step 5** (review prompts). Use this table as a quick ref
 | ------ | ----------- |
 | `#architect` | System design, service decomposition, ADR facilitation |
 | `#principal-engineer` | Architecture review, abstraction quality, long-term maintainability |
-| `#devops-engineer` | CI/CD, containerisation, IaC, secrets management, deployment reliability |
+| `#devops-engineer` | CI/CD, containerization, IaC, secrets management, deployment reliability |
 | `#qa-engineer` | Test coverage, quality risks, edge cases, regression strategy |
 | `#product-manager` | PRDs, user stories, acceptance criteria, feature scoping |
 
 ## Available skills
 
-Skills are specialised knowledge files. Load the relevant file at the start of any task in that
+Skills are specialized knowledge files. Load the relevant file at the start of any task in that
 domain — do not rely on general knowledge alone. Skills live in `.github/skills/`.
 
 | Load this file | When |

--- a/composed/python-copilot-instructions.md
+++ b/composed/python-copilot-instructions.md
@@ -38,7 +38,22 @@ git pull origin main
 - Record the issue number — you will need it for every subsequent step
 
 ```bash
-gh issue create --title "<type>(scope): short description" --body "Problem, solution, acceptance criteria" --assignee @me
+# Write the body to a temp file so newlines render correctly on GitHub
+cat > /tmp/issue-body.md << 'EOF'
+## Problem
+<describe the problem>
+
+## Proposed solution
+<describe the solution>
+
+## Acceptance criteria
+- [ ] <criterion 1>
+- [ ] <criterion 2>
+EOF
+
+gh issue create \
+  --title "<type>(scope): short description" \
+  --body-file /tmp/issue-body.md
 ```
 
 **Step 3 — Create a branch linked to that issue**

--- a/composed/typescript-copilot-instructions.md
+++ b/composed/typescript-copilot-instructions.md
@@ -76,7 +76,7 @@ without it.
 | Building | Invoke |
 | -------- | ------ |
 | A new CRUD resource | `#crud-api` |
-| Authentication / authorisation | `#auth` |
+| Authentication / authorization | `#auth` |
 | A new database, ORM, or migrations | `#database` |
 | A new UI component | `#frontend` |
 | An async background worker | `#background-jobs` |
@@ -89,7 +89,7 @@ without it.
 | ------ | ------ |
 | System design, service decomposition, or ADR | `#architect` |
 | Architecture quality or long-term maintainability concerns | `#principal-engineer` |
-| CI/CD, infrastructure, containerisation, or deployment | `#devops-engineer` |
+| CI/CD, infrastructure, containerization, or deployment | `#devops-engineer` |
 | Test strategy, quality risks, or edge case coverage | `#qa-engineer` |
 | Requirements, user stories, or acceptance criteria | `#product-manager` |
 
@@ -99,7 +99,7 @@ without it.
 
 **Implementation rules:**
 - Make only the changes required to resolve the issue.
-- Do not refactor unrelated code or add unrequested features.
+- Do not refactor unrelated code or add un-requested features.
 - If modifying any source file that feeds a composed output, edit the source and regenerate.
 
 **Step 5 — Run local validation**
@@ -249,7 +249,7 @@ All card transitions are **automated by `project-automation.yml`** — never mov
 - Use `GITHUB_TOKEN` for all same-repo workflow operations. It is automatic, expires after the workflow run, and requires no secrets configuration.
 - Always declare an explicit `permissions:` block in every workflow. Use job-level permissions for maximum granularity. Grant only what is required.
 - For cross-repository or cross-organization write access, prefer a **GitHub App** (installation access token) over a personal access token. For lightweight cases, a **fine-grained PAT** stored as a repository secret is acceptable.
-- Never use classic PATs in workflows — they are over-scoped and deprecated. **Exception:** GitHub Projects v2 (`addProjectV2ItemById`) requires the `project` scope, which is only available on classic PATs for personal (non-organisation) accounts. In that specific case, a classic PAT with only the `project` scope is acceptable and should be stored as a repository secret.
+- Never use classic PATs in workflows — they are over-scoped and deprecated. **Exception:** GitHub Projects v2 (`addProjectV2ItemById`) requires the `project` scope, which is only available on classic PATs for personal (non-organization) accounts. In that specific case, a classic PAT with only the `project` scope is acceptable and should be stored as a repository secret.
 - Pin action versions using the major version tag (e.g., `actions/checkout@v6`), not floating tags like `@latest` or `@main`.
 - Use `lts/*` for language version inputs (Node.js) and the equivalent latest-stable selector for other runtimes — never hardcode a specific version number in workflow files.
 
@@ -313,7 +313,7 @@ scaffold prompts) and **Step 5** (review prompts). Use this table as a quick ref
 | `#feature` | Implementing a new feature end-to-end |
 | `#bug` | Diagnosing and fixing a bug — reproduce first, then trace root cause |
 | `#test` | Writing tests for existing code |
-| `#refactor` | Refactoring without changing observable behaviour |
+| `#refactor` | Refactoring without changing observable behavior |
 | `#docs` | Generating or updating README, API docs, ADRs, or changelogs |
 | `#adr` | Recording an architecture decision in `docs/decisions/` |
 | `#deploy` | Deploying a service — pre-deploy checks, health verification, rollback plan |
@@ -333,7 +333,7 @@ scaffold prompts) and **Step 5** (review prompts). Use this table as a quick ref
 | Invoke | When to use |
 | ------ | ----------- |
 | `#crud-api` | Scaffolding a new CRUD resource (routes, models, validation, tests, migrations) |
-| `#auth` | Wiring authentication and authorisation into a project |
+| `#auth` | Wiring authentication and authorization into a project |
 | `#database` | Setting up a new database, ORM, migrations, and health checks |
 | `#frontend` | Scaffolding a new UI component (structure, a11y, state management, tests) |
 | `#background-jobs` | Scaffolding an async worker (queue, retry policy, dead-letter handling) |
@@ -346,13 +346,13 @@ scaffold prompts) and **Step 5** (review prompts). Use this table as a quick ref
 | ------ | ----------- |
 | `#architect` | System design, service decomposition, ADR facilitation |
 | `#principal-engineer` | Architecture review, abstraction quality, long-term maintainability |
-| `#devops-engineer` | CI/CD, containerisation, IaC, secrets management, deployment reliability |
+| `#devops-engineer` | CI/CD, containerization, IaC, secrets management, deployment reliability |
 | `#qa-engineer` | Test coverage, quality risks, edge cases, regression strategy |
 | `#product-manager` | PRDs, user stories, acceptance criteria, feature scoping |
 
 ## Available skills
 
-Skills are specialised knowledge files. Load the relevant file at the start of any task in that
+Skills are specialized knowledge files. Load the relevant file at the start of any task in that
 domain — do not rely on general knowledge alone. Skills live in `.github/skills/`.
 
 | Load this file | When |

--- a/composed/typescript-copilot-instructions.md
+++ b/composed/typescript-copilot-instructions.md
@@ -38,7 +38,22 @@ git pull origin main
 - Record the issue number — you will need it for every subsequent step
 
 ```bash
-gh issue create --title "<type>(scope): short description" --body "Problem, solution, acceptance criteria" --assignee @me
+# Write the body to a temp file so newlines render correctly on GitHub
+cat > /tmp/issue-body.md << 'EOF'
+## Problem
+<describe the problem>
+
+## Proposed solution
+<describe the solution>
+
+## Acceptance criteria
+- [ ] <criterion 1>
+- [ ] <criterion 2>
+EOF
+
+gh issue create \
+  --title "<type>(scope): short description" \
+  --body-file /tmp/issue-body.md
 ```
 
 **Step 3 — Create a branch linked to that issue**

--- a/instructions/api-design.instructions.md
+++ b/instructions/api-design.instructions.md
@@ -34,7 +34,7 @@ Never use GET for operations with side effects.
 | No content (DELETE / action with no body) | `204` |
 | Validation error (malformed request) | `400` |
 | Unauthenticated | `401` |
-| Forbidden (authenticated but not authorised) | `403` |
+| Forbidden (authenticated but not authorized) | `403` |
 | Not found | `404` |
 | Conflict (duplicate / business rule violation) | `409` |
 | Unprocessable entity (semantic validation) | `422` |
@@ -91,8 +91,8 @@ Never use GET for operations with side effects.
 ## Security
 
 - Authenticate every non-public endpoint.
-- Authorise at the resource level — verify the caller owns or has permission on the **specific resource**, not just that they are logged in (prevent IDOR).
+- Authorize at the resource level — verify the caller owns or has permission on the **specific resource**, not just that they are logged in (prevent IDOR).
 - Rate-limit all public and authenticated endpoints.
-- Sanitise all inputs; reject unknown fields at the schema level (`additionalProperties: false` / `model_config = ConfigDict(extra="forbid")` / `[JsonExtensionData]` avoided).
+- Sanitize all inputs; reject unknown fields at the schema level (`additionalProperties: false` / `model_config = ConfigDict(extra="forbid")` / `[JsonExtensionData]` avoided).
 - CORS: explicit allow-list origins; never `*` in production for credentialed requests.
 - `Content-Security-Policy`, `X-Content-Type-Options`, `X-Frame-Options` on all browser-facing responses.

--- a/instructions/auth-patterns.instructions.md
+++ b/instructions/auth-patterns.instructions.md
@@ -2,7 +2,7 @@
 applyTo: "**"
 ---
 
-# Authentication & Authorisation Patterns
+# Authentication & authorization Patterns
 
 These rules apply to any service that manages identity, sessions, tokens, or access control.
 
@@ -66,12 +66,12 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
   - `SameSite=Strict` or `SameSite=Lax` cookies mitigate most CSRF.
   - Add a CSRF token for state-changing requests when using `SameSite=None`.
 
-## Authorisation
+## authorization
 
-- Enforce authorisation at the **service / use-case layer**, not only at the controller/route layer.
+- Enforce authorization at the **service / use-case layer**, not only at the controller/route layer.
 - Use RBAC (roles → permissions) or ABAC (attribute-based) — not ad-hoc `if user.isAdmin` conditions scattered through code.
 - Principle of least privilege: grant only what the operation requires.
-- **Resource-level authorisation**: after authenticating a request, verify the caller owns or has explicit permission on the **specific resource** being accessed. This prevents IDOR (Insecure Direct Object Reference).
+- **Resource-level authorization**: after authenticating a request, verify the caller owns or has explicit permission on the **specific resource** being accessed. This prevents IDOR (Insecure Direct Object Reference).
 
 ```python
 # Python — always check ownership

--- a/instructions/base.md
+++ b/instructions/base.md
@@ -34,7 +34,22 @@ git pull origin main
 - Record the issue number — you will need it for every subsequent step
 
 ```bash
-gh issue create --title "<type>(scope): short description" --body "Problem, solution, acceptance criteria" --assignee @me
+# Write the body to a temp file so newlines render correctly on GitHub
+cat > /tmp/issue-body.md << 'EOF'
+## Problem
+<describe the problem>
+
+## Proposed solution
+<describe the solution>
+
+## Acceptance criteria
+- [ ] <criterion 1>
+- [ ] <criterion 2>
+EOF
+
+gh issue create \
+  --title "<type>(scope): short description" \
+  --body-file /tmp/issue-body.md
 ```
 
 **Step 3 — Create a branch linked to that issue**

--- a/instructions/base.md
+++ b/instructions/base.md
@@ -72,7 +72,7 @@ without it.
 | Building | Invoke |
 | -------- | ------ |
 | A new CRUD resource | `#crud-api` |
-| Authentication / authorisation | `#auth` |
+| Authentication / authorization | `#auth` |
 | A new database, ORM, or migrations | `#database` |
 | A new UI component | `#frontend` |
 | An async background worker | `#background-jobs` |
@@ -85,7 +85,7 @@ without it.
 | ------ | ------ |
 | System design, service decomposition, or ADR | `#architect` |
 | Architecture quality or long-term maintainability concerns | `#principal-engineer` |
-| CI/CD, infrastructure, containerisation, or deployment | `#devops-engineer` |
+| CI/CD, infrastructure, containerization, or deployment | `#devops-engineer` |
 | Test strategy, quality risks, or edge case coverage | `#qa-engineer` |
 | Requirements, user stories, or acceptance criteria | `#product-manager` |
 
@@ -95,7 +95,7 @@ without it.
 
 **Implementation rules:**
 - Make only the changes required to resolve the issue.
-- Do not refactor unrelated code or add unrequested features.
+- Do not refactor unrelated code or add un-requested features.
 - If modifying any source file that feeds a composed output, edit the source and regenerate.
 
 **Step 5 — Run local validation**
@@ -245,7 +245,7 @@ All card transitions are **automated by `project-automation.yml`** — never mov
 - Use `GITHUB_TOKEN` for all same-repo workflow operations. It is automatic, expires after the workflow run, and requires no secrets configuration.
 - Always declare an explicit `permissions:` block in every workflow. Use job-level permissions for maximum granularity. Grant only what is required.
 - For cross-repository or cross-organization write access, prefer a **GitHub App** (installation access token) over a personal access token. For lightweight cases, a **fine-grained PAT** stored as a repository secret is acceptable.
-- Never use classic PATs in workflows — they are over-scoped and deprecated. **Exception:** GitHub Projects v2 (`addProjectV2ItemById`) requires the `project` scope, which is only available on classic PATs for personal (non-organisation) accounts. In that specific case, a classic PAT with only the `project` scope is acceptable and should be stored as a repository secret.
+- Never use classic PATs in workflows — they are over-scoped and deprecated. **Exception:** GitHub Projects v2 (`addProjectV2ItemById`) requires the `project` scope, which is only available on classic PATs for personal (non-organization) accounts. In that specific case, a classic PAT with only the `project` scope is acceptable and should be stored as a repository secret.
 - Pin action versions using the major version tag (e.g., `actions/checkout@v6`), not floating tags like `@latest` or `@main`.
 - Use `lts/*` for language version inputs (Node.js) and the equivalent latest-stable selector for other runtimes — never hardcode a specific version number in workflow files.
 
@@ -309,7 +309,7 @@ scaffold prompts) and **Step 5** (review prompts). Use this table as a quick ref
 | `#feature` | Implementing a new feature end-to-end |
 | `#bug` | Diagnosing and fixing a bug — reproduce first, then trace root cause |
 | `#test` | Writing tests for existing code |
-| `#refactor` | Refactoring without changing observable behaviour |
+| `#refactor` | Refactoring without changing observable behavior |
 | `#docs` | Generating or updating README, API docs, ADRs, or changelogs |
 | `#adr` | Recording an architecture decision in `docs/decisions/` |
 | `#deploy` | Deploying a service — pre-deploy checks, health verification, rollback plan |
@@ -329,7 +329,7 @@ scaffold prompts) and **Step 5** (review prompts). Use this table as a quick ref
 | Invoke | When to use |
 | ------ | ----------- |
 | `#crud-api` | Scaffolding a new CRUD resource (routes, models, validation, tests, migrations) |
-| `#auth` | Wiring authentication and authorisation into a project |
+| `#auth` | Wiring authentication and authorization into a project |
 | `#database` | Setting up a new database, ORM, migrations, and health checks |
 | `#frontend` | Scaffolding a new UI component (structure, a11y, state management, tests) |
 | `#background-jobs` | Scaffolding an async worker (queue, retry policy, dead-letter handling) |
@@ -342,13 +342,13 @@ scaffold prompts) and **Step 5** (review prompts). Use this table as a quick ref
 | ------ | ----------- |
 | `#architect` | System design, service decomposition, ADR facilitation |
 | `#principal-engineer` | Architecture review, abstraction quality, long-term maintainability |
-| `#devops-engineer` | CI/CD, containerisation, IaC, secrets management, deployment reliability |
+| `#devops-engineer` | CI/CD, containerization, IaC, secrets management, deployment reliability |
 | `#qa-engineer` | Test coverage, quality risks, edge cases, regression strategy |
 | `#product-manager` | PRDs, user stories, acceptance criteria, feature scoping |
 
 ## Available skills
 
-Skills are specialised knowledge files. Load the relevant file at the start of any task in that
+Skills are specialized knowledge files. Load the relevant file at the start of any task in that
 domain — do not rely on general knowledge alone. Skills live in `.github/skills/`.
 
 | Load this file | When |

--- a/instructions/db-patterns.instructions.md
+++ b/instructions/db-patterns.instructions.md
@@ -17,7 +17,7 @@ These rules apply to any module that reads from or writes to a persistent data s
 - Never edit a migration that has already been applied to any shared environment — add a new one.
 - Document the intent of non-trivial migrations in a comment at the top of the file.
 
-## Parameterised queries only
+## Parameterized queries only
 
 No string concatenation or template literal interpolation for query values — ever.
 
@@ -58,7 +58,7 @@ var user = await db.Users.FromSqlRaw($"SELECT * FROM Users WHERE Id = '{id}'").F
   - SQLAlchemy: `session.execute(..., execution_options={"readonly": True})`
   - Prisma: default (no tracking); use `$transaction` only when needed
 - Wrap multi-step write operations in an explicit transaction.
-- Keep transactions short — commit or roll back as quickly as possible to minimise lock contention.
+- Keep transactions short — commit or roll back as quickly as possible to minimize lock contention.
 - Do not hold transactions open across HTTP calls or user interactions.
 
 ## N+1 prevention

--- a/instructions/testing.instructions.md
+++ b/instructions/testing.instructions.md
@@ -23,11 +23,11 @@ Never compensate for missing unit tests by writing more integration tests.
 - **New code:** minimum **80 % line coverage**, **70 % branch coverage**.
 - **Existing code:** do not reduce coverage when modifying a file.
 - Coverage is measured in CI on every PR — a drop blocks merge.
-- 100 % coverage is not the goal. Aim for coverage of behaviour, not lines.
+- 100 % coverage is not the goal. Aim for coverage of behavior, not lines.
 
 ## What to test
 
-**Test behaviour, not implementation:**
+**Test behavior, not implementation:**
 
 ```
 ✅ "returns 404 when user does not exist"
@@ -43,7 +43,7 @@ Never compensate for missing unit tests by writing more integration tests.
 **Integration tests must cover:**
 - The full request-response cycle for every route
 - Database reads and writes (use real DB, not mocks)
-- Auth middleware behaviour (authenticated, unauthenticated, wrong role)
+- Auth middleware behavior (authenticated, unauthenticated, wrong role)
 - At least one sad path per integration boundary
 
 **E2E tests must cover:**
@@ -90,7 +90,7 @@ Never name tests `test1`, `testFoo`, or `shouldWork`.
 - For database tests: wrap each test in a **transaction that is rolled back** after the test, or truncate tables in a `beforeEach`/`setUp` hook.
 - Never commit real PII (real email addresses, real phone numbers) into test fixtures.
 
-## Test organisation
+## Test organization
 
 - Co-locate unit tests next to the source file they test:
   - `src/users/user.service.ts` → `src/users/user.service.test.ts`

--- a/skills/code-analysis.skill.md
+++ b/skills/code-analysis.skill.md
@@ -23,7 +23,7 @@ For each code path, verify:
 - Are integer overflows or precision losses possible (floating point for money)?
 
 **Concurrency**
-- Are shared mutable objects accessed from multiple goroutines/threads/coroutines without synchronisation?
+- Are shared mutable objects accessed from multiple goroutines/threads/coroutines without synchronization?
 - Could `async` functions run concurrently when they must be sequential?
 - Are database operations that must be atomic wrapped in a transaction?
 

--- a/skills/performance-profiling.skill.md
+++ b/skills/performance-profiling.skill.md
@@ -4,8 +4,8 @@ This skill guides agents through systematic performance analysis. Load this file
 
 ## Phase 1 — Establish a baseline
 
-Before any optimisation:
-1. **Measure first, optimise second.** Never optimise without data.
+Before any optimization:
+1. **Measure first, optimize second.** Never optimize without data.
 2. Identify the metric that matters to users: latency (p99), throughput (RPS), or resource cost (CPU/memory).
 3. Record the baseline: `p50 = Xms, p95 = Yms, p99 = Zms` under N RPS.
 4. Identify the hot path: the code executed on every request / operation.
@@ -59,9 +59,9 @@ For any slow query (> 100 ms), run `EXPLAIN ANALYZE` and look for:
 - Look for large intermediate data structures (loading 10 MB into memory when streaming is possible)
 - Check for memory leaks: event listeners not removed, caches without eviction policies, long-lived references in closures
 
-### Serialisation and I/O
+### serialization and I/O
 
-- Are large JSON payloads serialised/deserialised on every request when they could be cached?
+- Are large JSON payloads serialized/deserialized on every request when they could be cached?
 - Are file reads/writes buffered or streaming appropriately?
 - Are connection pools configured with sensible min/max sizes?
 
@@ -108,4 +108,4 @@ Fix: <specific change>
 Expected improvement: <estimated impact>
 ```
 
-Only propose optimisations with measurable expected impact. Speculative micro-optimisations without a proven bottleneck are not findings.
+Only propose optimizations with measurable expected impact. Speculative micro-optimizations without a proven bottleneck are not findings.

--- a/skills/test-generation.skill.md
+++ b/skills/test-generation.skill.md
@@ -136,5 +136,5 @@ beforeEach(async () => {
 - [ ] No shared mutable state between tests
 - [ ] No `sleep` / `Thread.Sleep` calls
 - [ ] No vacuous assertions (`expect(true).toBe(true)`)
-- [ ] Test names describe behaviour, not implementation
+- [ ] Test names describe behavior, not implementation
 - [ ] No test marked as skipped without a linked issue

--- a/templates/memory/project-context.md
+++ b/templates/memory/project-context.md
@@ -61,7 +61,7 @@
 
 ## Key decisions (ADRs)
 
-<!-- Link or summarise the most important architectural decisions -->
+<!-- Link or summarize the most important architectural decisions -->
 | Decision | Rationale | Date |
 |----------|-----------|------|
 |          |           |      |


### PR DESCRIPTION
Closes #97

## Changes
- Added 'How to apply latest changes locally (without GitHub Actions)' subsection to README, with copy-pasteable onboard-repo.sh --force commands and a concrete example for the python+typescript my-blog project
- Renamed existing section to 'How to apply latest changes via GitHub Actions (remote)' for clarity
- Bundled 34 pending misc file improvements: prompts, instructions, skills, workflows (spelling corrections only), and templates

## Why
Developers with local clones of both the standards repo and a downstream repo had no documented path to apply standards updates without triggering GitHub Actions or waiting for the weekly Monday schedule.