### PR TITLE
fix(pull-standards): add workflows permission to allow pushing workflow files

### DIFF
--- a/workflows/sync/pull-standards.yml
+++ b/workflows/sync/pull-standards.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  workflows: write
 
 env:
   STANDARDS_REPO: h-urena/copilot-agentic-standards


### PR DESCRIPTION
Closes #99

## Changes
- Added workflows: write to the permissions block in workflows/sync/pull-standards.yml

## Why
Without this permission the GitHub App token cannot push a branch containing .github/workflows/*.yml files. The job fails with:
> refusing to allow a GitHub App to create or update workflow \.github/workflows/auto-fix.yml\ without \workflows\ permission

Note: my-blog's copy of pull-standards.yml has been patched locally (the sync workflow intentionally excludes pull-standards.yml from self-updating, so consumer repos need a one-time manual update or re-run of onboard-repo.sh --force).